### PR TITLE
Tweaks to reduce sketch size

### DIFF
--- a/STM32F1XX/cores/maple/cxxabi-compat.cpp
+++ b/STM32F1XX/cores/maple/cxxabi-compat.cpp
@@ -1,6 +1,11 @@
 /* We compile with nodefaultlibs, so we need to provide an error
  * handler for an empty pure virtual function */
 extern "C" void __cxa_pure_virtual(void) {
-    while(1)
-        ;
+    while(1);
+}
+/* Don't suck in exceptions, they bloat the code size */
+namespace __gnu_cxx {
+  void __verbose_terminate_handler() {
+      while(1);
+  }
 }


### PR DESCRIPTION
Spent some time trying to get the code size down, ended up getting a sketch that was 72k down to 18k.

I see that the compile options already include "-fno-exceptions", but I was having issues with them getting pulled in anyway.

I redefined "__verbose_terminate_handler" as is mentioned in a few places online. I also removed "-Wl,--whole-archive" in the linker options which bought another few k, I think "-Wl,--no-whole-archive" can also be removed but I'm no expert :)