### PR TITLE
fix HardwareSerial::begin by doing gpio_set_af_mode AF8 when devices are UART4 or UART5

### DIFF
--- a/STM32F4/cores/maple/libmaple/HardwareSerial.cpp
+++ b/STM32F4/cores/maple/libmaple/HardwareSerial.cpp
@@ -94,8 +94,14 @@ void HardwareSerial::begin(uint32 baud) {
     const stm32_pin_info *rxi = &PIN_MAP[rx_pin];
 #ifdef STM32F2
 	// int af = 7<<8;
-    gpio_set_af_mode(txi->gpio_device, txi->gpio_bit, 7);
-    gpio_set_af_mode(rxi->gpio_device, rxi->gpio_bit, 7);
+    if (usart_device == UART4 || usart_device == UART5) {
+        gpio_set_af_mode(txi->gpio_device, txi->gpio_bit, 8);
+        gpio_set_af_mode(rxi->gpio_device, rxi->gpio_bit, 8);
+    }
+    else {
+        gpio_set_af_mode(txi->gpio_device, txi->gpio_bit, 7);
+        gpio_set_af_mode(rxi->gpio_device, rxi->gpio_bit, 7);
+    }
     gpio_set_mode(txi->gpio_device, txi->gpio_bit, (gpio_pin_mode)(GPIO_AF_OUTPUT_PP | GPIO_PUPD_INPUT_PU | 0x700));
     gpio_set_mode(rxi->gpio_device, rxi->gpio_bit, (gpio_pin_mode)(GPIO_MODE_AF      | GPIO_PUPD_INPUT_PU | 0x700));
     //gpio_set_mode(txi->gpio_device, txi->gpio_bit, (gpio_pin_mode)(GPIO_PUPD_INPUT_PU));

--- a/STM32F4/libraries/arduino_uip/utility/Enc28J60Network.cpp
+++ b/STM32F4/libraries/arduino_uip/utility/Enc28J60Network.cpp
@@ -74,13 +74,13 @@ void Enc28J60Network::init(uint8_t* macaddr)
 #ifdef ENC28J60DEBUG
   Serial.println("ENC28J60::initialize / after initSPI()");
   Serial.print("ENC28J60::initialize / csPin = ");
-  Serial.println(ENC28J60_CONTROL_CS);
+  Serial.println(SPI.nssPin());
   Serial.print("ENC28J60::initialize / miso = ");
-  Serial.println(BOARD_SPI1_MISO_PIN);
+  Serial.println(SPI.misoPin());
   Serial.print("ENC28J60::initialize / mosi = ");
-  Serial.println(BOARD_SPI1_MOSI_PIN);
+  Serial.println(SPI.mosiPin());
   Serial.print("ENC28J60::initialize / sck = ");
-  Serial.println(BOARD_SPI1_SCK_PIN);
+  Serial.println(SPI.sckPin());
 #endif
   selectPin = ENC28J60_CONTROL_CS;
   pinMode(selectPin, OUTPUT);


### PR DESCRIPTION
Hi Roger,
Another small fix for a bug found in ad-hoc testing on my STM32F4Stamp.
