### PR TITLE
Fixes for Nucleo STM32F103RB

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -363,6 +363,7 @@ public:
     uint8 recv(void);
 	
 private:
+    void configure();
 /*
 	static inline void DMA1_CH3_Event() {
 		dma1_ch3_Active = 0;
@@ -374,7 +375,7 @@ private:
 */	
 	SPISettings _settings[BOARD_NR_SPI];
 	SPISettings *_currentSetting;
-	
+    bool _bIsMaster;
 	/*
 	spi_dev *spi_d;
 	uint8_t _SSPin;

--- a/STM32F1/libraries/Wire/HardWire.h
+++ b/STM32F1/libraries/Wire/HardWire.h
@@ -43,7 +43,7 @@
 #include "wirish.h"
 #include <libmaple/i2c.h>
 
-class HardWire : public WireBase {
+class HardWire : public TwoWire {
 private:
     i2c_dev* sel_hard;
     uint8    dev_flags;

--- a/STM32F1/libraries/Wire/Wire.cpp
+++ b/STM32F1/libraries/Wire/Wire.cpp
@@ -51,7 +51,7 @@
  * - always start with i2c_delay rather than end
  */
 
-void TwoWire::set_scl(bool state) {
+void SoftWire::set_scl(bool state) {
     I2C_DELAY(this->i2c_delay);
     digitalWrite(this->scl_pin,state);
     //Allow for clock stretching - dangerous currently
@@ -60,23 +60,23 @@ void TwoWire::set_scl(bool state) {
     }
 }
 
-void TwoWire::set_sda(bool state) {
-	I2C_DELAY(this->i2c_delay);
+void SoftWire::set_sda(bool state) {
+    I2C_DELAY(this->i2c_delay);
     digitalWrite(this->sda_pin, state);
 }
 
-void TwoWire::i2c_start() {
+void SoftWire::i2c_start() {
     set_sda(LOW);
     set_scl(LOW);
 }
 
-void TwoWire::i2c_stop() {
+void SoftWire::i2c_stop() {
     set_sda(LOW);
     set_scl(HIGH);
     set_sda(HIGH);
 }
 
-bool TwoWire::i2c_get_ack() {
+bool SoftWire::i2c_get_ack() {
     set_scl(LOW);
     set_sda(HIGH);
     set_scl(HIGH);
@@ -86,19 +86,19 @@ bool TwoWire::i2c_get_ack() {
     return ret;
 }
 
-void TwoWire::i2c_send_ack() {
+void SoftWire::i2c_send_ack() {
     set_sda(LOW);
     set_scl(HIGH);
     set_scl(LOW);
 }
 
-void TwoWire::i2c_send_nack() {
+void SoftWire::i2c_send_nack() {
     set_sda(HIGH);
     set_scl(HIGH);
     set_scl(LOW);
 }
 
-uint8 TwoWire::i2c_shift_in() {
+uint8 SoftWire::i2c_shift_in() {
     uint8 data = 0;
     set_sda(HIGH);
 
@@ -112,7 +112,7 @@ uint8 TwoWire::i2c_shift_in() {
     return data;
 }
 
-void TwoWire::i2c_shift_out(uint8 val) {
+void SoftWire::i2c_shift_out(uint8 val) {
     int i;
     for (i = 0; i < 8; i++) {
         set_sda(!!(val & (1 << (7 - i)) ) );
@@ -121,7 +121,7 @@ void TwoWire::i2c_shift_out(uint8 val) {
     }
 }
 
-uint8 TwoWire::process() {
+uint8 SoftWire::process() {
     itc_msg.xferred = 0;
 
     uint8 sla_addr = (itc_msg.addr << 1);
@@ -131,21 +131,21 @@ uint8 TwoWire::process() {
     i2c_start();
     // shift out the address we're transmitting to
     i2c_shift_out(sla_addr);
-    if (!i2c_get_ack()) 
-	{
-		i2c_stop();// Roger Clark. 20141110 added to set clock high again, as it will be left in a low state otherwise
+    if (!i2c_get_ack())
+    {
+        i2c_stop();// Roger Clark. 20141110 added to set clock high again, as it will be left in a low state otherwise
         return ENACKADDR;
     }
     // Recieving
     if (itc_msg.flags == I2C_MSG_READ) {
         while (itc_msg.xferred < itc_msg.length) {
             itc_msg.data[itc_msg.xferred++] = i2c_shift_in();
-            if (itc_msg.xferred < itc_msg.length) 
-			{
+            if (itc_msg.xferred < itc_msg.length)
+            {
                 i2c_send_ack();
-            } 
-			else 
-			{
+            }
+            else
+            {
                 i2c_send_nack();
             }
         }
@@ -154,9 +154,9 @@ uint8 TwoWire::process() {
     else {
         for (uint8 i = 0; i < itc_msg.length; i++) {
             i2c_shift_out(itc_msg.data[i]);
-            if (!i2c_get_ack()) 
-			{
-				i2c_stop();// Roger Clark. 20141110 added to set clock high again, as it will be left in a low state otherwise
+            if (!i2c_get_ack())
+            {
+                i2c_stop();// Roger Clark. 20141110 added to set clock high again, as it will be left in a low state otherwise
                 return ENACKTRNS;
             }
             itc_msg.xferred++;
@@ -168,12 +168,12 @@ uint8 TwoWire::process() {
 
 // TODO: Add in Error Handling if pins is out of range for other Maples
 // TODO: Make delays more capable
-TwoWire::TwoWire(uint8 scl, uint8 sda, uint8 delay) : i2c_delay(delay) {
+SoftWire::SoftWire(uint8 scl, uint8 sda, uint8 delay) : i2c_delay(delay) {
     this->scl_pin=scl;
     this->sda_pin=sda;
 }
 
-void TwoWire::begin(uint8 self_addr) {
+void SoftWire::begin(uint8 self_addr) {
     tx_buf_idx = 0;
     tx_buf_overflow = false;
     rx_buf_idx = 0;
@@ -184,11 +184,11 @@ void TwoWire::begin(uint8 self_addr) {
     set_sda(HIGH);
 }
 
-TwoWire::~TwoWire() {
+SoftWire::~SoftWire() {
     this->scl_pin=0;
     this->sda_pin=0;
 }
 
 // Declare the instance that the users of the library can use
 //TwoWire Wire(SCL, SDA, SOFT_STANDARD);
-TwoWire Wire(PB6, PB7, SOFT_STANDARD);
+SoftWire Wire(PB6, PB7, SOFT_STANDARD);

--- a/STM32F1/libraries/Wire/Wire.h
+++ b/STM32F1/libraries/Wire/Wire.h
@@ -60,7 +60,7 @@
 #define BUFFER_LENGTH 32
 
 
-class TwoWire : public WireBase {
+class SoftWire : public TwoWire {
  public:
     uint8 		i2c_delay;
     uint8       scl_pin;
@@ -121,7 +121,7 @@ class TwoWire : public WireBase {
      * Accept pin numbers for SCL and SDA lines. Set the delay needed
      * to create the timing for I2C's Standard Mode and Fast Mode.
      */
-    TwoWire(uint8 scl=SCL, uint8 sda=SDA, uint8 delay=SOFT_STANDARD);
+    SoftWire(uint8 scl=SCL, uint8 sda=SDA, uint8 delay=SOFT_STANDARD);
 
     /*
      * Sets pins SDA and SCL to OUPTUT_OPEN_DRAIN, joining I2C bus as
@@ -133,9 +133,9 @@ class TwoWire : public WireBase {
     /*
      * If object is destroyed, set pin numbers to 0.
      */
-    ~TwoWire();
+    ~SoftWire();
 };
 
-extern TwoWire Wire;
+extern SoftWire Wire;
 
 #endif // _WIRE_H_

--- a/STM32F1/libraries/Wire/WireBase.cpp
+++ b/STM32F1/libraries/Wire/WireBase.cpp
@@ -91,35 +91,42 @@ uint8 WireBase::requestFrom(int address, int numBytes) {
     return WireBase::requestFrom((uint8)address, numBytes);
 }
 
-void WireBase::write(uint8 value) {
+bool WireBase::write(uint8 value) {
     if (tx_buf_idx == WIRE_BUFSIZ) {
         tx_buf_overflow = true;
-        return;
+        return false;
     }
     tx_buf[tx_buf_idx++] = value;
     itc_msg.length++;
+    return true;
 }
 
-void WireBase::write(uint8* buf, int len) {
+bool WireBase::write(uint8* buf, int len) {
     for (uint8 i = 0; i < len; i++) {
-        write(buf[i]);
+        if(!write(buf[i])) {
+            return false;
+        }
     }
+    return true;
 }
 
-void WireBase::write(int value) {
-    write((uint8)value);
+bool WireBase::write(int value) {
+    return write((uint8)value);
 }
 
-void WireBase::write(int* buf, int len) {
-    write((uint8*)buf, (uint8)len);
+bool WireBase::write(int* buf, int len) {
+    return write((uint8*)buf, (uint8)len);
 }
 
-void WireBase::write(char* buf) {
+bool WireBase::write(char* buf) {
     uint8 *ptr = (uint8*)buf;
     while (*ptr) {
-        write(*ptr);
+        if(!write(*ptr)){
+            return false;
+        }
         ptr++;
     }
+    return true;
 }
 
 uint8 WireBase::available() {

--- a/STM32F1/libraries/Wire/WireBase.cpp
+++ b/STM32F1/libraries/Wire/WireBase.cpp
@@ -41,25 +41,25 @@
 #include "WireBase.h"
 #include "wirish.h"
 
-void WireBase::begin(uint8 self_addr) {
+void TwoWire::begin(uint8 self_addr) {
     tx_buf_idx = 0;
     tx_buf_overflow = false;
     rx_buf_idx = 0;
     rx_buf_len = 0;
 }
 
-void WireBase::beginTransmission(uint8 slave_address) {
+void TwoWire::beginTransmission(uint8 slave_address) {
     itc_msg.addr = slave_address;
     itc_msg.data = &tx_buf[tx_buf_idx];
     itc_msg.length = 0;
     itc_msg.flags = 0;
 }
 
-void WireBase::beginTransmission(int slave_address) {
+void TwoWire::beginTransmission(int slave_address) {
     beginTransmission((uint8)slave_address);
 }
 
-uint8 WireBase::endTransmission(void) {
+uint8 TwoWire::endTransmission(void) {
     uint8 retVal;
     if (tx_buf_overflow) {
         return EDATA;
@@ -73,7 +73,7 @@ uint8 WireBase::endTransmission(void) {
 //TODO: Add the ability to queue messages (adding a boolean to end of function
 // call, allows for the Arduino style to stay while also giving the flexibility
 // to bulk send
-uint8 WireBase::requestFrom(uint8 address, int num_bytes) {
+uint8 TwoWire::requestFrom(uint8 address, int num_bytes) {
     if (num_bytes > WIRE_BUFSIZ) {
         num_bytes = WIRE_BUFSIZ;
     }
@@ -87,11 +87,11 @@ uint8 WireBase::requestFrom(uint8 address, int num_bytes) {
     return rx_buf_len;
 }
 
-uint8 WireBase::requestFrom(int address, int numBytes) {
-    return WireBase::requestFrom((uint8)address, numBytes);
+uint8 TwoWire::requestFrom(int address, int numBytes) {
+    return TwoWire::requestFrom((uint8)address, numBytes);
 }
 
-bool WireBase::write(uint8 value) {
+bool TwoWire::write(uint8 value) {
     if (tx_buf_idx == WIRE_BUFSIZ) {
         tx_buf_overflow = true;
         return false;
@@ -101,7 +101,7 @@ bool WireBase::write(uint8 value) {
     return true;
 }
 
-bool WireBase::write(uint8* buf, int len) {
+bool TwoWire::write(uint8* buf, int len) {
     for (uint8 i = 0; i < len; i++) {
         if(!write(buf[i])) {
             return false;
@@ -110,15 +110,15 @@ bool WireBase::write(uint8* buf, int len) {
     return true;
 }
 
-bool WireBase::write(int value) {
+bool TwoWire::write(int value) {
     return write((uint8)value);
 }
 
-bool WireBase::write(int* buf, int len) {
+bool TwoWire::write(int* buf, int len) {
     return write((uint8*)buf, (uint8)len);
 }
 
-bool WireBase::write(char* buf) {
+bool TwoWire::write(char* buf) {
     uint8 *ptr = (uint8*)buf;
     while (*ptr) {
         if(!write(*ptr)){
@@ -129,11 +129,11 @@ bool WireBase::write(char* buf) {
     return true;
 }
 
-uint8 WireBase::available() {
+uint8 TwoWire::available() {
     return rx_buf_len - rx_buf_idx;
 }
 
-uint8 WireBase::read() {
+uint8 TwoWire::read() {
     if (rx_buf_idx == rx_buf_len) {
         rx_buf_idx = 0;
         rx_buf_len = 0;

--- a/STM32F1/libraries/Wire/WireBase.h
+++ b/STM32F1/libraries/Wire/WireBase.h
@@ -106,27 +106,27 @@ public:
     /*
      * Stack up bytes to be sent when transmitting
      */
-    void write(uint8);
+    bool write(uint8);
 
     /*
      * Stack up bytes from the array to be sent when transmitting
      */
-    void write(uint8*, int);
+    bool write(uint8*, int);
 
     /*
      * Ensure that a sending data will only be 8-bit bytes
      */
-    void write(int);
+    bool write(int);
 
     /*
      * Ensure that an array sending data will only be 8-bit bytes
      */
-    void write(int*, int);
+    bool write(int*, int);
 
     /*
      * Stack up bytes from a string to be sent when transmitting
      */
-    void write(char*);
+    bool write(char*);
 
     /*
      * Return the amount of bytes that is currently in the receiving buffer

--- a/STM32F1/libraries/Wire/WireBase.h
+++ b/STM32F1/libraries/Wire/WireBase.h
@@ -53,7 +53,7 @@
 #define ENACKTRNS 3        /* received nack on transmit of data */
 #define EOTHER    4        /* other error */
 
-class WireBase { // Abstraction is awesome!
+class TwoWire { // Abstraction is awesome!
 protected:
     i2c_msg itc_msg;
     uint8 rx_buf[WIRE_BUFSIZ];      /* receive buffer */
@@ -67,8 +67,8 @@ protected:
     // Force derived classes to define process function
     virtual uint8 process() = 0;
 public:
-    WireBase() {}
-    ~WireBase() {}
+    TwoWire() {}
+    ~TwoWire() {}
 
     /*
      * Initialises the class interface

--- a/STM32F1/variants/nucleo_f103rb/board.cpp
+++ b/STM32F1/variants/nucleo_f103rb/board.cpp
@@ -253,7 +253,7 @@ MOSI alternate functions on the GPIO ports.
    DEFINE_HWSERIAL(Serial2, 2);
    DEFINE_HWSERIAL(Serial3, 3);
 #else
-   DEFINE_HWSERIAL(Serial, 3);// Use HW Serial 2 as "Serial"
-   DEFINE_HWSERIAL(Serial1, 2);
-   DEFINE_HWSERIAL(Serial2, 1);
+   DEFINE_HWSERIAL(Serial1, 1);
+   DEFINE_HWSERIAL(Serial, 2);// Use HW Serial 2 as "Serial"
+   DEFINE_HWSERIAL(Serial2, 3);
 #endif


### PR DESCRIPTION
1. Mapping USART2 to Serial instead of USART1
2. WireBase write functions return type set to boolean, so that calling functions can check that there's no buffer overflow.