### PR TITLE
Changed install.sh script to check for uucp group which is typical of Arch Linux

### DIFF
--- a/tools/linux/45-maple .rules.arch
+++ b/tools/linux/45-maple .rules.arch
@@ -1,0 +1,4 @@
+SUBSYSTEM=="usb", ATTRS{idProduct}=="1001", ATTRS{idVendor}=="0110", MODE="0666", GROUP="uucp"
+SUBSYSTEM=="usb", ATTRS{idProduct}=="1002", ATTRS{idVendor}=="0110", MODE="0666", GROUP="uucp"
+SUBSYSTEM=="usb", ATTRS{idProduct}=="0003", ATTRS{idVendor}=="1eaf", MODE="0666", GROUP="uucp" SYMLINK+="maple"
+SUBSYSTEM=="usb", ATTRS{idProduct}=="0004", ATTRS{idVendor}=="1eaf", MODE="0666", GROUP="uucp" SYMLINK+="maple"

--- a/tools/linux/install.sh
+++ b/tools/linux/install.sh
@@ -1,14 +1,25 @@
 #!/bin/sh
 
+#Arch uses the uucp group, dialout is depricated
+retUUCP=false
+getent group uucp $1 >/dev/null 2>&1 && retUUCP=true
+
 if sudo [ -w /etc/udev/rules.d ]; then
     echo "Copying Maple-specific udev rules..."
-    sudo cp -v 45-maple.rules /etc/udev/rules.d/45-maple.rules
+    if $retUUCP
+    then
+        echo "Adding current user to uucp group"
+        sudo usermod -a -G uucp $USER
+        sudo cp -v 45-maple.rules.arch /etc/udev/rules.d/45-maple.rules
+    else
+        echo "Adding current user to dialout group"
+        sudo adduser $USER dialout
+        sudo cp -v 45-maple.rules /etc/udev/rules.d/45-maple.rules
+    fi
     sudo chown root:root /etc/udev/rules.d/45-maple.rules
     sudo chmod 644 /etc/udev/rules.d/45-maple.rules
     echo "Reloading udev rules"
     sudo udevadm control --reload-rules
-    echo "Adding current user to dialout group"
-    sudo adduser $USER dialout
 else
     echo "Couldn't copy to /etc/udev/rules.d/; you probably have to run this script as root? Or your distribution of Linux doesn't include udev; try running the IDE itself as root."
 fi


### PR DESCRIPTION
Improved the linux install script to check if the [uucp](https://en.wikipedia.org/wiki/UUCP) group exists as is typical on [Arch](https://www.archlinux.org/) 

If the group is found it will copy the modified udev rules (Subsystem USB, Group uucp, Mode 0666)

See [Users and Groups](https://wiki.archlinux.org/index.php/Users_and_groups#User_groups) in the Arch wiki for groups.

plugdev does not exist on Arch