### PR TITLE
Fix file open to actually turn on inbound parity checking.

### DIFF
--- a/tools/src/stm32flash_serial/src/serial_posix.c
+++ b/tools/src/stm32flash_serial/src/serial_posix.c
@@ -128,8 +128,8 @@ static port_err_t serial_setup(serial_t *h, const serial_baud_t baud,
 
 	switch (parity) {
 		case SERIAL_PARITY_NONE: port_parity = 0; break;
-		case SERIAL_PARITY_EVEN: port_parity = INPCK | PARENB; break;
-		case SERIAL_PARITY_ODD:  port_parity = INPCK | PARENB | PARODD; break;
+		case SERIAL_PARITY_EVEN: port_parity = PARENB; break;
+		case SERIAL_PARITY_ODD:  port_parity = PARENB | PARODD; break;
 
 		default:
 			return PORT_ERR_UNKNOWN;
@@ -149,6 +149,9 @@ static port_err_t serial_setup(serial_t *h, const serial_baud_t baud,
 #else /* __sun */
 	h->newtio.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR
 			       | IGNCR | ICRNL | IXON);
+        if (port_parity)
+                h->newtio.c_iflag |= INPCK;
+
 	h->newtio.c_oflag &= ~OPOST;
 	h->newtio.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
 	h->newtio.c_cflag &= ~(CSIZE | PARENB);


### PR DESCRIPTION
The INPCK bit is an i_flag bit, not a c_flag bit as originally done
here. I have no idea what setting INPCK in c_flag does on Linux, but
on FreeBSD it caused the test of the c_values after they were set to
fail. This fixes that, and presumably the serial interface will now
actually check the parity of incoming data.