### PR TITLE
run at 48 MHz off the internal RC oscillator

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -130,7 +130,7 @@ nucleo_f103rb.upload.altID=1
 nucleo_f103rb.upload.auto_reset=true
 
 nucleo_f103rb.build.mcu=cortex-m3
-nucleo_f103rb.build.f_cpu=72000000L
+nucleo_f103rb.build.f_cpu=48000000L
 nucleo_f103rb.build.board=STM_NUCLEU_F103RB
 nucleo_f103rb.build.core=maple
 nucleo_f103rb.build.extra_flags=-DMCU_STM32F103RB -mthumb    -march=armv7-m  -D__STM32F1__ 
@@ -143,6 +143,37 @@ nucleo_f103rb.build.error_led_port=GPIOB
 nucleo_f103rb.build.error_led_pin=1
 nucleo_f103rb.build.gcc_ver=gcc-arm-none-eabi-4.8.3-2014q1
 nucleo_f103rb.build.vect=VECT_TAB_ADDR=0x8000000
+
+##############################################################
+nucleo_f103rb_hse.name=STM Nucleo F103RB w/ crystal (STLink)
+
+nucleo_f103rb_hse.upload.tool=stlink_upload
+nucleo_f103rb_hse.upload.protocol=maple_dfu
+nucleo_f103rb_hse.upload.maximum_size=108000
+nucleo_f103rb_hse.upload.use_1200bps_touch=false
+nucleo_f103rb_hse.upload.file_type=bin
+nucleo_f103rb_hse.upload.ram.maximum_size=17000
+nucleo_f103rb_hse.upload.flash.maximum_size=108000
+nucleo_f103rb_hse.upload.params.quiet=no
+
+nucleo_f103rb_hse.upload.usbID=1EAF:0003
+nucleo_f103rb_hse.upload.altID=1
+nucleo_f103rb_hse.upload.auto_reset=true
+
+nucleo_f103rb_hse.build.mcu=cortex-m3
+nucleo_f103rb_hse.build.f_cpu=72000000L
+nucleo_f103rb_hse.build.board=STM_NUCLEU_F103RB
+nucleo_f103rb_hse.build.core=maple
+nucleo_f103rb_hse.build.extra_flags=-DNUCLEO_HSE_CRYSTAL -DMCU_STM32F103RB -mthumb    -march=armv7-m  -D__STM32F1__ 
+nucleo_f103rb_hse.build.ldscript=ld/jtag.ld
+nucleo_f103rb_hse.build.variant=nucleo_f103rb
+nucleo_f103rb_hse.build.variant_system_lib=libmaple.a
+nucleo_f103rb_hse.build.vect=VECT_TAB_FLASH
+nucleo_f103rb_hse.build.density=STM32_MEDIUM_DENSITY
+nucleo_f103rb_hse.build.error_led_port=GPIOB
+nucleo_f103rb_hse.build.error_led_pin=1
+nucleo_f103rb_hse.build.gcc_ver=gcc-arm-none-eabi-4.8.3-2014q1
+nucleo_f103rb_hse.build.vect=VECT_TAB_ADDR=0x8000000
 
 ###################### Generic STM32F103C  ########################################
 

--- a/STM32F1/variants/nucleo_f103rb/wirish/boards.cpp
+++ b/STM32F1/variants/nucleo_f103rb/wirish/boards.cpp
@@ -122,9 +122,9 @@ static void setup_clocks(void) {
     RCC_BASE->CIR = 0x00000000;
 
     // Enable HSE, and wait until it's ready.
-    rcc_turn_on_clk(RCC_CLK_HSE);
-    while (!rcc_is_clk_ready(RCC_CLK_HSE))
-        ;
+    //rcc_turn_on_clk(RCC_CLK_HSE);
+    //while (!rcc_is_clk_ready(RCC_CLK_HSE))
+    //    ;
 
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();

--- a/STM32F1/variants/nucleo_f103rb/wirish/boards.cpp
+++ b/STM32F1/variants/nucleo_f103rb/wirish/boards.cpp
@@ -121,10 +121,12 @@ static void setup_clocks(void) {
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
 
+#ifdef NUCLEO_HSE_CRYSTAL
     // Enable HSE, and wait until it's ready.
-    //rcc_turn_on_clk(RCC_CLK_HSE);
-    //while (!rcc_is_clk_ready(RCC_CLK_HSE))
-    //    ;
+    rcc_turn_on_clk(RCC_CLK_HSE);
+    while (!rcc_is_clk_ready(RCC_CLK_HSE))
+        ;
+#endif
 
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();

--- a/STM32F1/variants/nucleo_f103rb/wirish/boards_setup.cpp
+++ b/STM32F1/variants/nucleo_f103rb/wirish/boards_setup.cpp
@@ -48,15 +48,15 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
-#define BOARD_RCC_PLLMUL RCC_PLLMUL_9
+#define BOARD_RCC_PLLMUL RCC_PLLMUL_12
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
-        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
-        __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+        __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_4;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 
         __weak void board_reset_pll(void) {
@@ -71,7 +71,7 @@ namespace wirish {
 			#if F_CPU == 72000000
 			rcc_set_prescaler(RCC_PRESCALER_USB, RCC_USB_SYSCLK_DIV_1_5);
 			#elif F_CPU == 48000000
-			rcc_set_prescaler(RCC_PRESCALER_USB, RCC_USB_SYSCLK_DIV_1_5);			
+			rcc_set_prescaler(RCC_PRESCALER_USB, RCC_USB_SYSCLK_DIV_1);			
 			#endif	
         }
 

--- a/STM32F1/variants/nucleo_f103rb/wirish/boards_setup.cpp
+++ b/STM32F1/variants/nucleo_f103rb/wirish/boards_setup.cpp
@@ -48,15 +48,27 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+#ifdef NUCLEO_HSE_CRYSTAL
+// with crystal, run at 9x8, i.e. 72 MHz
+#define BOARD_RCC_PLLMUL RCC_PLLMUL_9
+#else
+// without crystal, run at 12x8/2, i.e. 48 MHz (max would be 64)
+// only 48 & 72 support USB, but without crystal the clock is not stable enough
 #define BOARD_RCC_PLLMUL RCC_PLLMUL_12
+#endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#ifdef NUCLEO_HSE_CRYSTAL
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+        __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
+#else
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_4;
+#endif
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 
         __weak void board_reset_pll(void) {


### PR DESCRIPTION
This change only applies to the Nucleo F103RB board:

Make the system clock run from the internal RC clock i.s.o. a crystal (which is not present by default on a Nucleo). Set up the PLL to run at 48 MHz (72 is not supported, 64 is max).

(feel free to drop this pull request if you don't want to merge it)