### PR TITLE
wait for time to elapse instead of a cycle-counting loop

### DIFF
--- a/STM32F1/cores/maple/wirish_time.cpp
+++ b/STM32F1/cores/maple/wirish_time.cpp
@@ -34,10 +34,9 @@
 #include <libmaple/delay.h>
 
 void delay(unsigned long ms) {
-    uint32 i;
-    for (i = 0; i < ms; i++) {
-        delayMicroseconds(1000);
-    }
+    uint32 start = millis();
+    while (millis() - start < ms)
+        ;
 }
 
 void delayMicroseconds(uint32 us) {


### PR DESCRIPTION
see discusssion on the forum at http://www.stm32duino.com/viewtopic.php?f=3&t=695&p=7601#p7601

This change makes delay() wait for millis() to report the requested passing of time. The original code uses delay_us() in system/libmaple/include/libmaple/delay.h, which counts processor cycles. The delay will be too long if there is background interrupt activity.