### PR TITLE
support Nucleo without and with crystal

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -125,7 +125,7 @@ nucleo_f103rb.upload.altID=1
 nucleo_f103rb.upload.auto_reset=true
 
 nucleo_f103rb.build.mcu=cortex-m3
-nucleo_f103rb.build.board=STM_NUCLEU_F103RB
+nucleo_f103rb.build.board=STM_NUCLEO_F103RB
 nucleo_f103rb.build.core=maple
 nucleo_f103rb.build.ldscript=ld/jtag.ld
 nucleo_f103rb.build.variant=nucleo_f103rb

--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -125,10 +125,8 @@ nucleo_f103rb.upload.altID=1
 nucleo_f103rb.upload.auto_reset=true
 
 nucleo_f103rb.build.mcu=cortex-m3
-nucleo_f103rb.build.f_cpu=72000000L
 nucleo_f103rb.build.board=STM_NUCLEU_F103RB
 nucleo_f103rb.build.core=maple
-nucleo_f103rb.build.extra_flags=-DMCU_STM32F103RB -mthumb -march=armv7-m -D__STM32F1__
 nucleo_f103rb.build.ldscript=ld/jtag.ld
 nucleo_f103rb.build.variant=nucleo_f103rb
 nucleo_f103rb.build.variant_system_lib=libmaple.a
@@ -138,6 +136,16 @@ nucleo_f103rb.build.error_led_port=GPIOB
 nucleo_f103rb.build.error_led_pin=1
 nucleo_f103rb.build.gcc_ver=gcc-arm-none-eabi-4.8.3-2014q1
 nucleo_f103rb.build.vect=VECT_TAB_ADDR=0x8000000
+
+## internal oscillator (HSI), running at 64 MHz
+nucleo_f103rb.menu.device_variant.NucleoF103_HSI=Nucleo F103 @ 64 MHz
+nucleo_f103rb.menu.device_variant.NucleoF103_HSI.build.f_cpu=64000000L
+nucleo_f103rb.menu.device_variant.NucleoF103_HSI.build.extra_flags=-DMCU_STM32F103RB -mthumb -march=armv7-m -D__STM32F1__
+
+## external crystal (HSE), running at 72 MHz
+nucleo_f103rb.menu.device_variant.NucleoF103_HSE=Nucleo F103 @ 72 MHz w/ crystal
+nucleo_f103rb.menu.device_variant.NucleoF103_HSE.build.f_cpu=72000000L
+nucleo_f103rb.menu.device_variant.NucleoF103_HSE.build.extra_flags=-DNUCLEO_HSE_CRYSTAL -DMCU_STM32F103RB -mthumb -march=armv7-m -D__STM32F1__
 
 ###################### Generic STM32F103C ########################################
 

--- a/STM32F1/variants/nucleo_f103rb/wirish/boards.cpp
+++ b/STM32F1/variants/nucleo_f103rb/wirish/boards.cpp
@@ -121,10 +121,12 @@ static void setup_clocks(void) {
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
 
+#if NUCLEO_HSE_CRYSTAL
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
+#endif
 
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();

--- a/STM32F1/variants/nucleo_f103rb/wirish/boards_setup.cpp
+++ b/STM32F1/variants/nucleo_f103rb/wirish/boards_setup.cpp
@@ -48,14 +48,22 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+#if NUCLEO_HSE_CRYSTAL
 #define BOARD_RCC_PLLMUL RCC_PLLMUL_9
+#else
+#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+#endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if NUCLEO_HSE_CRYSTAL
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 
@@ -71,7 +79,7 @@ namespace wirish {
 			#if F_CPU == 72000000
 			rcc_set_prescaler(RCC_PRESCALER_USB, RCC_USB_SYSCLK_DIV_1_5);
 			#elif F_CPU == 48000000
-			rcc_set_prescaler(RCC_PRESCALER_USB, RCC_USB_SYSCLK_DIV_1_5);			
+			rcc_set_prescaler(RCC_PRESCALER_USB, RCC_USB_SYSCLK_DIV_1);			
 			#endif	
         }
 


### PR DESCRIPTION
This has now been set up as two variants on the same Nucleo F103 menu entry.
The default, i.e. first variant is the official crystall-less version @ 64 MHz.
The other one is what was already in the project - i.e. kept at 72 MHz and supporting USB.

Supersedes PR #126.