### PR TITLE
Relax stm32flash checks (again)

### DIFF
--- a/tools/src/stm32flash_serial/src/serial_posix.c
+++ b/tools/src/stm32flash_serial/src/serial_posix.c
@@ -182,11 +182,18 @@ static port_err_t serial_setup(serial_t *h, const serial_baud_t baud,
 	if (tcsetattr(h->fd, TCSANOW, &h->newtio) != 0)
 		return PORT_ERR_UNKNOWN;
 
+/* this check fails on CDC-ACM devices, bits 16 and 17 of cflag differ!
+ * it has been disabled below for now -jcw, 2015-11-09
+    if (settings.c_cflag != h->newtio.c_cflag)
+        fprintf(stderr, "c_cflag mismatch %lx\n",
+                settings.c_cflag ^ h->newtio.c_cflag);
+ */
+
 	/* confirm they were set */
 	tcgetattr(h->fd, &settings);
 	if (settings.c_iflag != h->newtio.c_iflag ||
 	    settings.c_oflag != h->newtio.c_oflag ||
-	    settings.c_cflag != h->newtio.c_cflag ||
+	  //settings.c_cflag != h->newtio.c_cflag ||
 	    settings.c_lflag != h->newtio.c_lflag)
 		return PORT_ERR_UNKNOWN;
 


### PR DESCRIPTION
This change to the stm32flash utility is needed to be able to open CDC-ACM type serial USB devices on at least Mac OSX (maybe also Linux).

It removes a check that the cflag value ends up precisely as expected by stm32flash. I don't think this is important in this context.

One more step will be needed to fully address this PR: it needs re-built versions of stm32flash for at Lac OSX and Linux (Windows code is not affected by this change).

Replaces incorrect PR #139.