### PR TITLE
corrected defines needed when parity is used in HardwareSerial

### DIFF
--- a/STM32F1/cores/maple/HardwareSerial.cpp
+++ b/STM32F1/cores/maple/HardwareSerial.cpp
@@ -141,11 +141,11 @@ void HardwareSerial::begin(uint32 baud, uint8_t config)
 
     disable_timer_if_necessary(txi->timer_device, txi->timer_channel);
 
+    usart_init(this->usart_device);
     usart_config_gpios_async(this->usart_device,
                              rxi->gpio_device, rxi->gpio_bit,
                              txi->gpio_device, txi->gpio_bit,
                              config);
-    usart_init(this->usart_device);
     usart_set_baud_rate(this->usart_device, USART_USE_PCLK, baud);
     usart_enable(this->usart_device);
 }

--- a/STM32F1/cores/maple/HardwareSerial.h
+++ b/STM32F1/cores/maple/HardwareSerial.h
@@ -83,22 +83,25 @@ struct usart_dev;
  */
 // Define config for Serial.begin(baud, config);
 // Note. STM32 doesn't support as many different Serial modes as AVR or SAM cores.
+// The word legth bit M must be set when using parity bit.
 
 #define SERIAL_8N1	0B00000000
 #define SERIAL_8N2	0B00100000
 #define SERIAL_9N1	0B00001000
 #define SERIAL_9N2	0B00101000	
 
-#define SERIAL_8E1	0B00000010
-#define SERIAL_8E2	0B00100010
+#define SERIAL_8E1	0B00001010
+#define SERIAL_8E2	0B00101010
+/* not supported:
 #define SERIAL_9E1	0B00001010
 #define SERIAL_9E2	0B00101010
-
-#define SERIAL_8O1	0B00000011
-#define SERIAL_8O2	0B00100011
+*/
+#define SERIAL_8O1	0B00001011
+#define SERIAL_8O2	0B00101011
+/* not supported:
 #define SERIAL_9O1	0B00001011
 #define SERIAL_9O2	0B00101011
-
+*/
 
 /* Roger Clark 
  * Moved macros from hardwareSerial.cpp

--- a/STM32F1/cores/maple/libmaple/usart_f1.c
+++ b/STM32F1/cores/maple/libmaple/usart_f1.c
@@ -108,13 +108,14 @@ void usart_config_gpios_async(usart_dev *udev,
     gpio_set_mode(rx_dev, rx, GPIO_INPUT_FLOATING);
     gpio_set_mode(tx_dev, tx, GPIO_AF_OUTPUT_PP);
 /*
-
 CR1 bit 12 Word length 0=8  1=9 
 CR1 bit 11 wake (default value is 0) we can safely set this value to 0 (zero) each time 
 CR1 bit 10 parity enable (1 = enabled)
 CR1 bit 9  Parity selection 0 = Even  1 = Odd
 CR2 bits 13 and 12  00 = 1 01 = 0.5 10 = 2 11 = 1.5
 Not all USARTs support 1.5 or 0.5 bits so its best to avoid them.
+When parity enabled the word length must be increased (CR1 bit 12 set).
+Word length of 9 bit with parity is not supported.
 	CR2  CR1
 	0B00 0000
 	0B10 0000
@@ -136,21 +137,19 @@ Not all USARTs support 1.5 or 0.5 bits so its best to avoid them.
 #define SERIAL_9N1	0B 0000 1000
 #define SERIAL_9N2	0B 0010 1000	
 
-#define SERIAL_8E1	0B 0000 0010
-#define SERIAL_8E2	0B 0010 0010
-#define SERIAL_9E1	0B 0000 1010
-#define SERIAL_9E2	0B 0010 1010
+#define SERIAL_8E1	0B 0000 1010
+#define SERIAL_8E2	0B 0010 1010
+//#define SERIAL_9E1	0B 0000 1010
+//#define SERIAL_9E2	0B 0010 1010
 
-#define SERIAL_8O1	0B 0000 0011
-#define SERIAL_8O2	0B 0010 0011
-#define SERIAL_9O1	0B 0000 1011
-#define SERIAL_9O2	0B 0010 1011	
-	
-	*/
+#define SERIAL_8O1	0B 0000 1011
+#define SERIAL_8O2	0B 0010 1011
+//#define SERIAL_9O1	0B 0000 1011
+//#define SERIAL_9O2	0B 0010 1011
+*/
 
-
-	udev->regs->CR1  = udev->regs->CR1 ^ ((udev->regs->CR1 ^ (flags&0x0F)<<9 )  &  0B0001111000000000); 
-	udev->regs->CR2  = udev->regs->CR2 ^ ((udev->regs->CR2 ^ (flags&0xF0)<<8 ) &   0B0011000000000000); 			
+	udev->regs->CR1  = (udev->regs->CR1 & 0B1110000111111111) | ((uint32_t)(flags&0x0F)<<9);
+	udev->regs->CR2  = (udev->regs->CR2 & 0B1100111111111111) | ((uint32_t)(flags&0x30)<<8);
 }
 
 void usart_set_baud_rate(usart_dev *dev, uint32 clock_speed, uint32 baud) {


### PR DESCRIPTION
When the parity control is enabled, the computed parity is inserted at the MSB position (9th bit if M=1; 8th bit if M=0) and parity is checked on the received data. This excludes 9 bit long words + parity bit in the 10th position.