### PR TITLE
Make sure both USB_ISTR_SUSP & USB_ISTR_WKUP are both cleared when US…

### DIFF
--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb.c
@@ -210,7 +210,7 @@ void __irq_usb_lp_can_rx0(void) {
 
 #if (USB_ISR_MSK & USB_ISTR_WKUP)
     if (istr & USB_ISTR_WKUP & USBLIB->irq_mask) {
-        USB_BASE->ISTR = ~USB_ISTR_WKUP;
+        USB_BASE->ISTR = ~(USB_ISTR_WKUP | USB_ISTR_SUSP);
         usb_resume(RESUME_EXTERNAL);
     }
 #endif
@@ -225,7 +225,7 @@ void __irq_usb_lp_can_rx0(void) {
             usb_resume(RESUME_LATER);
         }
         /* clear of the ISTR bit must be done after setting of CNTR_FSUSP */
-        USB_BASE->ISTR = ~USB_ISTR_SUSP;
+        USB_BASE->ISTR = ~(USB_ISTR_WKUP | USB_ISTR_SUSP);
     }
 #endif
 

--- a/STM32F1/cores/maple/usb_serial.cpp
+++ b/STM32F1/cores/maple/usb_serial.cpp
@@ -106,7 +106,7 @@ size_t n = 0;
 
 size_t USBSerial::write(const void *buf, uint32 len) {
 size_t n = 0;
-    if (!this->isConnected() || !usb_cdcacm_get_dtr() || !buf) {
+    if (!this->isConnected() || !buf) {
         return 0;
     }
 
@@ -199,7 +199,7 @@ uint8 USBSerial::pending(void) {
 }
 
 uint8 USBSerial::isConnected(void) {
-    return usb_is_connected(USBLIB) && usb_is_configured(USBLIB);
+    return usb_is_connected(USBLIB) && usb_is_configured(USBLIB) && usb_cdcacm_get_dtr();
 }
 
 uint8 USBSerial::getDTR(void) {

--- a/STM32F1/cores/maple/usb_serial.cpp
+++ b/STM32F1/cores/maple/usb_serial.cpp
@@ -106,7 +106,7 @@ size_t n = 0;
 
 size_t USBSerial::write(const void *buf, uint32 len) {
 size_t n = 0;
-    if (!this->isConnected() || !buf) {
+    if (!this->isConnected() || !usb_cdcacm_get_dtr() || !buf) {
         return 0;
     }
 


### PR DESCRIPTION
…B susppends or resumes.
This is required as when we see a suspend event it looks like we immediately afterwords trigger a resume from the bit being set previously.