### PR TITLE
Install udev-rules for ST-link

### DIFF
--- a/tools/linux/49-stlinkv1.rules
+++ b/tools/linux/49-stlinkv1.rules
@@ -1,0 +1,11 @@
+# stm32 discovery boards, with onboard st/linkv1
+# ie, STM32VL
+
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3744", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv1_%n"
+
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.

--- a/tools/linux/49-stlinkv2-1.rules
+++ b/tools/linux/49-stlinkv2-1.rules
@@ -1,0 +1,12 @@
+# stm32 nucleo boards, with onboard st/linkv2-1
+# ie, STM32F0, STM32F4.
+# STM32VL has st/linkv1, which is quite different
+
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv2-1_%n"
+
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.

--- a/tools/linux/49-stlinkv2.rules
+++ b/tools/linux/49-stlinkv2.rules
@@ -1,0 +1,12 @@
+# stm32 discovery boards, with onboard st/linkv2
+# ie, STM32L, STM32F4.
+# STM32VL has st/linkv1, which is quite different
+
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv2_%n"
+
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.

--- a/tools/linux/install.sh
+++ b/tools/linux/install.sh
@@ -5,6 +5,15 @@ if sudo [ -w /etc/udev/rules.d ]; then
     sudo cp -v 45-maple.rules /etc/udev/rules.d/45-maple.rules
     sudo chown root:root /etc/udev/rules.d/45-maple.rules
     sudo chmod 644 /etc/udev/rules.d/45-maple.rules
+    sudo cp -v 49-stlinkv1.rules /etc/udev/rules.d/49-stlinkv1.rules
+    sudo chown root:root /etc/udev/rules.d/49-stlinkv1.rules
+    sudo chmod 644 /etc/udev/rules.d/49-stlinkv1.rules
+    sudo cp -v 49-stlinkv2.rules /etc/udev/rules.d/49-stlinkv2.rules
+    sudo chown root:root /etc/udev/rules.d/49-stlinkv2.rules
+    sudo chmod 644 /etc/udev/rules.d/49-stlinkv2.rules
+    sudo cp -v 49-stlinkv2-1.rules /etc/udev/rules.d/49-stlinkv2-1.rules
+    sudo chown root:root /etc/udev/rules.d/49-stlinkv2-1.rules
+    sudo chmod 644 /etc/udev/rules.d/49-stlinkv2-1.rules
     echo "Reloading udev rules"
     sudo udevadm control --reload-rules
     echo "Adding current user to dialout group"


### PR DESCRIPTION
As the title says, install udev-rules for being able to use ST-link to upload sketches without having to be root.