### PR TITLE
F1 Usart improvements

### DIFF
--- a/STM32F1/cores/maple/HardwareSerial.cpp
+++ b/STM32F1/cores/maple/HardwareSerial.cpp
@@ -117,11 +117,6 @@ static void disable_timer_if_necessary(timer_dev *dev, uint8 ch) {
 #warning "Unsupported STM32 series; timer conflicts are possible"
 #endif
 
-void HardwareSerial::begin(uint32 baud) 
-{
-    beginNew(baud);
-}
-
 /*
  * Roger Clark.
  * Note. The config parameter is not currently used. This is a work in progress.  

--- a/STM32F1/cores/maple/HardwareSerial.cpp
+++ b/STM32F1/cores/maple/HardwareSerial.cpp
@@ -117,25 +117,23 @@ static void disable_timer_if_necessary(timer_dev *dev, uint8 ch) {
 #warning "Unsupported STM32 series; timer conflicts are possible"
 #endif
 
-/*
 void HardwareSerial::begin(uint32 baud) 
 {
-    begin(baud, SERIAL_8N1);
+    beginNew(baud);
 }
 
-void HardwareSerial::begin(uint32 baud, uint8_t config) 
-{
-    begin(baud, config, SERIAL_RX_BUFFER_SIZE, SERIAL_TX_BUFFER_SIZE);
-}
-*/
 /*
  * Roger Clark.
  * Note. The config parameter is not currently used. This is a work in progress.  
  * Code needs to be written to set the config of the hardware serial control register in question.
  *
 */
+void HardwareSerial::begin(uint32 baud, uint8_t config) 
+{
+    beginNew(baud, SERIAL_RX_BUFFER_SIZE, SERIAL_TX_BUFFER_SIZE, config);
+}
 
-void HardwareSerial::begin(uint32 baud, uint16 tx_buf_size, uint16 rx_buf_size, uint8_t config)
+void HardwareSerial::beginNew(uint32 baud, uint16 tx_buf_size, uint16 rx_buf_size, uint8_t config)
 {
  //   ASSERT(baud <= this->usart_device->max_baud);// Roger Clark. Assert doesn't do anything useful, we may as well save the space in flash and ram etc
 

--- a/STM32F1/cores/maple/HardwareSerial.cpp
+++ b/STM32F1/cores/maple/HardwareSerial.cpp
@@ -117,10 +117,17 @@ static void disable_timer_if_necessary(timer_dev *dev, uint8 ch) {
 #warning "Unsupported STM32 series; timer conflicts are possible"
 #endif
 
+/*
 void HardwareSerial::begin(uint32 baud) 
 {
-	begin(baud,SERIAL_8N1);
+    begin(baud, SERIAL_8N1);
 }
+
+void HardwareSerial::begin(uint32 baud, uint8_t config) 
+{
+    begin(baud, config, SERIAL_RX_BUFFER_SIZE, SERIAL_TX_BUFFER_SIZE);
+}
+*/
 /*
  * Roger Clark.
  * Note. The config parameter is not currently used. This is a work in progress.  
@@ -128,7 +135,7 @@ void HardwareSerial::begin(uint32 baud)
  *
 */
 
-void HardwareSerial::begin(uint32 baud, uint8_t config) 
+void HardwareSerial::begin(uint32 baud, uint16 tx_buf_size, uint16 rx_buf_size, uint8_t config)
 {
  //   ASSERT(baud <= this->usart_device->max_baud);// Roger Clark. Assert doesn't do anything useful, we may as well save the space in flash and ram etc
 
@@ -141,7 +148,10 @@ void HardwareSerial::begin(uint32 baud, uint8_t config)
 
     disable_timer_if_necessary(txi->timer_device, txi->timer_channel);
 
-    usart_init(this->usart_device);
+    rx_buf_size = rx_buf_size < 16 ? 16 : rx_buf_size; // min RX buf size = 16
+    tx_buf_size = tx_buf_size == 0 ? 1 : tx_buf_size; // min TX buf size = 1
+    
+    usart_init_new(this->usart_device, rx_buf_size, tx_buf_size);
     usart_config_gpios_async(this->usart_device,
                              rxi->gpio_device, rxi->gpio_bit,
                              txi->gpio_device, txi->gpio_bit,
@@ -183,15 +193,23 @@ int HardwareSerial::availableForWrite(void)
  * so just return 1, meaning that 1 char can be written
  * This will be slower than a ring buffer implementation, but it should at least work !
  */
-  return 1;
+  return !(rb_is_full(this->usart_device->wb));
 }
 
 size_t HardwareSerial::write(unsigned char ch) {
 
     usart_putc(this->usart_device, ch);
-	return 1;
+    return 1;
 }
 
 void HardwareSerial::flush(void) {
     usart_reset_rx(this->usart_device);
+}
+
+void HardwareSerial::enableBlockingTx(void) {
+    usart_enabableBlockingTX(this->usart_device);
+}
+
+void HardwareSerial::disableBlockingTx(void) {
+    usart_disabableBlockingTX(this->usart_device);
 }

--- a/STM32F1/cores/maple/HardwareSerial.cpp
+++ b/STM32F1/cores/maple/HardwareSerial.cpp
@@ -125,7 +125,7 @@ static void disable_timer_if_necessary(timer_dev *dev, uint8 ch) {
 */
 void HardwareSerial::begin(uint32 baud, uint8_t config) 
 {
-    beginNew(baud, SERIAL_RX_BUFFER_SIZE, SERIAL_TX_BUFFER_SIZE, config);
+    beginNew(baud, SERIAL_TX_BUFFER_SIZE, SERIAL_RX_BUFFER_SIZE, config);
 }
 
 void HardwareSerial::beginNew(uint32 baud, uint16 tx_buf_size, uint16 rx_buf_size, uint8_t config)

--- a/STM32F1/cores/maple/HardwareSerial.h
+++ b/STM32F1/cores/maple/HardwareSerial.h
@@ -130,9 +130,9 @@ public:
                    uint8 rx_pin);
 
     /* Set up/tear down */
-    //void begin(uint32 baud);
-    //void begin(uint32 baud,uint8_t config);
-    void begin(uint32 baud, uint16 tx_buf_size=SERIAL_TX_BUFFER_SIZE, uint16 rx_buf_size=SERIAL_RX_BUFFER_SIZE, uint8_t config=SERIAL_8N1);
+    void begin(uint32 baud);
+    void begin(uint32 baud,uint8_t config);
+    void beginNew(uint32 baud, uint16 tx_buf_size=SERIAL_TX_BUFFER_SIZE, uint16 rx_buf_size=SERIAL_RX_BUFFER_SIZE, uint8_t config=SERIAL_8N1);
     void end();
     virtual int available(void);
     virtual int peek(void);

--- a/STM32F1/cores/maple/HardwareSerial.h
+++ b/STM32F1/cores/maple/HardwareSerial.h
@@ -88,7 +88,7 @@ struct usart_dev;
 #define SERIAL_8N1	0B00000000
 #define SERIAL_8N2	0B00100000
 #define SERIAL_9N1	0B00001000
-#define SERIAL_9N2	0B00101000	
+#define SERIAL_9N2	0B00101000
 
 #define SERIAL_8E1	0B00001010
 #define SERIAL_8E2	0B00101010
@@ -130,8 +130,9 @@ public:
                    uint8 rx_pin);
 
     /* Set up/tear down */
-    void begin(uint32 baud);
-    void begin(uint32 baud,uint8_t config);
+    //void begin(uint32 baud);
+    //void begin(uint32 baud,uint8_t config);
+    void begin(uint32 baud, uint16 tx_buf_size=SERIAL_TX_BUFFER_SIZE, uint16 rx_buf_size=SERIAL_RX_BUFFER_SIZE, uint8_t config=SERIAL_8N1);
     void end();
     virtual int available(void);
     virtual int peek(void);
@@ -148,16 +149,22 @@ public:
     /* Pin accessors */
     int txPin(void) { return this->tx_pin; }
     int rxPin(void) { return this->rx_pin; }
-	
-	operator bool() { return true; }
+    
+    operator bool() { return true; }
 
     /* Escape hatch into libmaple */
     /* FIXME [0.0.13] documentation */
     struct usart_dev* c_dev(void) { return this->usart_device; }
+
+    void enableBlockingTx(void);
+    void disableBlockingTx(void);
+
 private:
     struct usart_dev *usart_device;
     uint8 tx_pin;
     uint8 rx_pin;
+    uint8 *rx_buf = NULL;
+    uint8 *tx_buf = NULL;
   protected:
 #if 0  
     volatile uint8_t * const _ubrrh;

--- a/STM32F1/cores/maple/HardwareSerial.h
+++ b/STM32F1/cores/maple/HardwareSerial.h
@@ -130,8 +130,7 @@ public:
                    uint8 rx_pin);
 
     /* Set up/tear down */
-    void begin(uint32 baud);
-    void begin(uint32 baud,uint8_t config);
+    void begin(uint32 baud,uint8_t config=SERIAL_8N1);
     void beginNew(uint32 baud, uint16 tx_buf_size=SERIAL_TX_BUFFER_SIZE, uint16 rx_buf_size=SERIAL_RX_BUFFER_SIZE, uint8_t config=SERIAL_8N1);
     void end();
     virtual int available(void);

--- a/STM32F1/cores/maple/libmaple/ring_buffer.c
+++ b/STM32F1/cores/maple/libmaple/ring_buffer.c
@@ -1,0 +1,10 @@
+#include <libmaple/ring_buffer.h>
+
+void rb_init(ring_buffer *rb, uint16 size) {
+    rb->head = 0;
+    rb->used = 0;
+    rb->size = size == 0 ? 1 : size;
+    if(rb->buf != NULL)
+        free(rb->buf); // free previously allocated buffer if any
+    rb->buf = (uint8 *) malloc(rb->size * sizeof(uint8));
+}

--- a/STM32F1/cores/maple/libmaple/ring_buffer.c
+++ b/STM32F1/cores/maple/libmaple/ring_buffer.c
@@ -1,10 +1,16 @@
 #include <libmaple/ring_buffer.h>
 
-void rb_init(ring_buffer *rb, uint16 size) {
+void rb_init_new(ring_buffer *rb, uint16 size) {
     rb->head = 0;
     rb->used = 0;
-    rb->size = size == 0 ? 1 : size;
-    if(rb->buf != NULL)
-        free(rb->buf); // free previously allocated buffer if any
-    rb->buf = (uint8 *) malloc(rb->size * sizeof(uint8));
+    size = size == 0 ? 1 : size;
+    if(rb->size != size) 
+    {
+        // (rb->size != size) means either no buffer allocated yet or new buffer size different from old buffer size 
+        //                    this leads to the need to deallocate the old buffer (if any) and allocate the new one
+        if(rb->buf != NULL)
+            free(rb->buf);
+        rb->buf = (uint8 *) malloc(size * sizeof(uint8));
+        rb->size = size;
+    }
 }

--- a/STM32F1/cores/maple/libmaple/usart.c
+++ b/STM32F1/cores/maple/libmaple/usart.c
@@ -56,8 +56,8 @@ void usart_init(usart_dev *dev) {
  * @param tx_buf_size Size of TX buffer
  */
 void usart_init_new(usart_dev *dev,uint16 rx_buf_size,uint16 tx_buf_size) {
-    rb_init(dev->rb, rx_buf_size);
-    rb_init(dev->wb, tx_buf_size);
+    rb_init_new(dev->rb, rx_buf_size);
+    rb_init_new(dev->wb, tx_buf_size);
     rcc_clk_enable(dev->clk_id);
     nvic_irq_enable(dev->irq_num);
     dev->blockingTx = 1; // default to blocking TX

--- a/STM32F1/cores/maple/libmaple/usart.c
+++ b/STM32F1/cores/maple/libmaple/usart.c
@@ -124,7 +124,6 @@ uint32 usart_tx(usart_dev *dev, const uint8 *buf, uint32 len) {
     if (rb_full_count(dev->wb) > 0) {
         regs->CR1 |= USART_CR1_TXEIE;
     }
-    
     return txed;
 }
 

--- a/STM32F1/cores/maple/libmaple/usart_f1.c
+++ b/STM32F1/cores/maple/libmaple/usart_f1.c
@@ -40,10 +40,12 @@
  * Devices
  */
 
-static ring_buffer usart1_rb;
+static ring_buffer usart1_rb = {0};
+static ring_buffer usart1_wb = {0};
 static usart_dev usart1 = {
     .regs     = USART1_BASE,
     .rb       = &usart1_rb,
+    .wb       = &usart1_wb,
     .max_baud = 4500000UL,
     .clk_id   = RCC_USART1,
     .irq_num  = NVIC_USART1,
@@ -51,10 +53,12 @@ static usart_dev usart1 = {
 /** USART1 device */
 usart_dev *USART1 = &usart1;
 
-static ring_buffer usart2_rb;
+static ring_buffer usart2_rb = {0};
+static ring_buffer usart2_wb = {0};
 static usart_dev usart2 = {
     .regs     = USART2_BASE,
     .rb       = &usart2_rb,
+    .wb       = &usart2_wb,
     .max_baud = 2250000UL,
     .clk_id   = RCC_USART2,
     .irq_num  = NVIC_USART2,
@@ -62,10 +66,12 @@ static usart_dev usart2 = {
 /** USART2 device */
 usart_dev *USART2 = &usart2;
 
-static ring_buffer usart3_rb;
+static ring_buffer usart3_rb = {0};
+static ring_buffer usart3_wb = {0};
 static usart_dev usart3 = {
     .regs     = USART3_BASE,
     .rb       = &usart3_rb,
+    .wb       = &usart3_wb,
     .max_baud = 2250000UL,
     .clk_id   = RCC_USART3,
     .irq_num  = NVIC_USART3,
@@ -74,10 +80,12 @@ static usart_dev usart3 = {
 usart_dev *USART3 = &usart3;
 
 #if defined(STM32_HIGH_DENSITY) || defined(STM32_XL_DENSITY)
-static ring_buffer uart4_rb;
+static ring_buffer uart4_rb = {0};
+static ring_buffer uart4_wb = {0};
 static usart_dev uart4 = {
     .regs     = UART4_BASE,
     .rb       = &uart4_rb,
+    .wb       = &uart4_wb,
     .max_baud = 2250000UL,
     .clk_id   = RCC_UART4,
     .irq_num  = NVIC_UART4,
@@ -85,10 +93,12 @@ static usart_dev uart4 = {
 /** UART4 device */
 usart_dev *UART4 = &uart4;
 
-static ring_buffer uart5_rb;
+static ring_buffer uart5_rb = {0};
+static ring_buffer uart5_wb = {0};
 static usart_dev uart5 = {
     .regs     = UART5_BASE,
     .rb       = &uart5_rb,
+    .wb       = &uart5_wb,
     .max_baud = 2250000UL,
     .clk_id   = RCC_UART5,
     .irq_num  = NVIC_UART5,
@@ -191,23 +201,23 @@ void usart_foreach(void (*fn)(usart_dev*)) {
  */
 
 void __irq_usart1(void) {
-    usart_irq(&usart1_rb, USART1_BASE);
+    usart_irq(&usart1_rb, &usart1_wb, USART1_BASE);
 }
 
 void __irq_usart2(void) {
-    usart_irq(&usart2_rb, USART2_BASE);
+    usart_irq(&usart2_rb, &usart2_wb, USART2_BASE);
 }
 
 void __irq_usart3(void) {
-    usart_irq(&usart3_rb, USART3_BASE);
+    usart_irq(&usart3_rb, &usart3_wb, USART3_BASE);
 }
 
 #ifdef STM32_HIGH_DENSITY
 void __irq_uart4(void) {
-    usart_irq(&uart4_rb, UART4_BASE);
+    usart_irq(&uart4_rb, &uart4_wb, UART4_BASE);
 }
 
 void __irq_uart5(void) {
-    usart_irq(&uart5_rb, UART5_BASE);
+    usart_irq(&uart5_rb, &uart5_wb, UART5_BASE);
 }
 #endif

--- a/STM32F1/cores/maple/libmaple/usart_f1.c
+++ b/STM32F1/cores/maple/libmaple/usart_f1.c
@@ -40,8 +40,8 @@
  * Devices
  */
 
-static ring_buffer usart1_rb = {0};
-static ring_buffer usart1_wb = {0};
+static ring_buffer usart1_rb;
+static ring_buffer usart1_wb;
 static usart_dev usart1 = {
     .regs     = USART1_BASE,
     .rb       = &usart1_rb,
@@ -53,8 +53,8 @@ static usart_dev usart1 = {
 /** USART1 device */
 usart_dev *USART1 = &usart1;
 
-static ring_buffer usart2_rb = {0};
-static ring_buffer usart2_wb = {0};
+static ring_buffer usart2_rb;
+static ring_buffer usart2_wb;
 static usart_dev usart2 = {
     .regs     = USART2_BASE,
     .rb       = &usart2_rb,
@@ -66,8 +66,8 @@ static usart_dev usart2 = {
 /** USART2 device */
 usart_dev *USART2 = &usart2;
 
-static ring_buffer usart3_rb = {0};
-static ring_buffer usart3_wb = {0};
+static ring_buffer usart3_rb;
+static ring_buffer usart3_wb;
 static usart_dev usart3 = {
     .regs     = USART3_BASE,
     .rb       = &usart3_rb,
@@ -80,8 +80,8 @@ static usart_dev usart3 = {
 usart_dev *USART3 = &usart3;
 
 #if defined(STM32_HIGH_DENSITY) || defined(STM32_XL_DENSITY)
-static ring_buffer uart4_rb = {0};
-static ring_buffer uart4_wb = {0};
+static ring_buffer uart4_rb;
+static ring_buffer uart4_wb;
 static usart_dev uart4 = {
     .regs     = UART4_BASE,
     .rb       = &uart4_rb,
@@ -93,8 +93,8 @@ static usart_dev uart4 = {
 /** UART4 device */
 usart_dev *UART4 = &uart4;
 
-static ring_buffer uart5_rb = {0};
-static ring_buffer uart5_wb = {0};
+static ring_buffer uart5_rb;
+static ring_buffer uart5_wb;
 static usart_dev uart5 = {
     .regs     = UART5_BASE,
     .rb       = &uart5_rb,

--- a/STM32F1/system/libmaple/include/libmaple/ring_buffer.h
+++ b/STM32F1/system/libmaple/include/libmaple/ring_buffer.h
@@ -44,17 +44,16 @@ extern "C"{
 /**
  * Ring buffer type.
  *
- * The buffer is empty when head == tail.
+ * The buffer is empty when used == 0.
  *
- * The buffer is full when the head is one byte in front of the tail,
- * modulo buffer length.
+ * The buffer is full when used == size.
  *
- * One byte is left free to distinguish empty from full. */
+ * This implementation allows using the full buffer size instead of the buffer size - 1. */
 typedef struct ring_buffer {
     volatile uint8 *buf; /**< Buffer items are stored into */
     uint16 head;         /**< Index of the next item to remove */
-    uint16 tail;         /**< Index where the next item will get inserted */
-    uint16 size;         /**< Buffer capacity minus one */
+    uint16 used;         /**< Amount of used buffer */
+    uint16 size;         /**< Buffer size */
 } ring_buffer;
 
 /**
@@ -62,31 +61,25 @@ typedef struct ring_buffer {
  *
  *  @param rb   Instance to initialise
  *
- *  @param size Number of items in buf.  The ring buffer will always
- *              leave one element unoccupied, so the maximum number of
- *              elements it can store will be size - 1.  Thus, size
- *              must be at least 2.
+ *  @param size Number of items in buf
  *
  *  @param buf  Buffer to store items into
  */
+inline void rb_init(ring_buffer *rb, uint16 size);
+/*
 static inline void rb_init(ring_buffer *rb, uint16 size, uint8 *buf) {
     rb->head = 0;
-    rb->tail = 0;
-    rb->size = size - 1;
+    rb->used = 0;
+    rb->size = size;
     rb->buf = buf;
 }
-
+*/
 /**
  * @brief Return the number of elements stored in the ring buffer.
  * @param rb Buffer whose elements to count.
  */
 static inline uint16 rb_full_count(ring_buffer *rb) {
-    __io ring_buffer *arb = rb;
-    int32 size = arb->tail - arb->head;
-    if (arb->tail < arb->head) {
-        size += arb->size + 1;
-    }
-    return (uint16)size;
+    return rb->used;
 }
 
 /**
@@ -94,8 +87,7 @@ static inline uint16 rb_full_count(ring_buffer *rb) {
  * @param rb Buffer to test.
  */
 static inline int rb_is_full(ring_buffer *rb) {
-    return (rb->tail + 1 == rb->head) ||
-        (rb->tail == rb->size && rb->head == 0);
+    return rb->used == rb->size;
 }
 
 /**
@@ -103,7 +95,7 @@ static inline int rb_is_full(ring_buffer *rb) {
  * @param rb Buffer to test.
  */
 static inline int rb_is_empty(ring_buffer *rb) {
-    return rb->head == rb->tail;
+    return rb->used == 0;
 }
 
 /**
@@ -112,17 +104,25 @@ static inline int rb_is_empty(ring_buffer *rb) {
  * @param element Value to append.
  */
 static inline void rb_insert(ring_buffer *rb, uint8 element) {
-    rb->buf[rb->tail] = element;
-    rb->tail = (rb->tail == rb->size) ? 0 : rb->tail + 1;
+    if(rb->used < rb->size)
+    {
+        rb->buf[(rb->head + rb->used) % rb->size] = element;
+        rb->used += 1;
+    }
 }
 
 /**
  * @brief Remove and return the first item from a ring buffer.
  * @param rb Buffer to remove from, must contain at least one element.
  */
-static inline uint8 rb_remove(ring_buffer *rb) {
-    uint8 ch = rb->buf[rb->head];
-    rb->head = (rb->head == rb->size) ? 0 : rb->head + 1;
+static inline int16 rb_remove(ring_buffer *rb) {
+    int16 ch = -1;
+    if(rb->used > 0)
+    {
+        ch = rb->buf[rb->head];
+        rb->head = (rb->head + 1) % rb->size;
+        rb->used -= 1;
+    }
     return ch;
 }
 
@@ -133,16 +133,9 @@ static inline uint8 rb_remove(ring_buffer *rb) {
  * @param rb Buffer to remove from, must contain at least one element.
  */
 
-static inline int rb_peek(ring_buffer *rb) 
+static inline int16 rb_peek(ring_buffer *rb) 
 {  
-	if (rb->head == rb->tail)
-	{
-		return -1;
-	}
-	else
-	{
-		return rb->buf[rb->head];
-	}
+    return rb->used == 0 ? -1 : rb->buf[rb->head];
 }
 
 
@@ -155,7 +148,7 @@ static inline int rb_peek(ring_buffer *rb)
  * @param rb Buffer to attempt to remove from.
  */
 static inline int16 rb_safe_remove(ring_buffer *rb) {
-    return rb_is_empty(rb) ? -1 : rb_remove(rb);
+    return rb_remove(rb);
 }
 
 /**
@@ -184,7 +177,7 @@ static inline int rb_safe_insert(ring_buffer *rb, uint8 element) {
  * @return On success, returns -1.  If an element was popped, returns
  *         the popped value.
  */
-static inline int rb_push_insert(ring_buffer *rb, uint8 element) {
+static inline int16 rb_push_insert(ring_buffer *rb, uint8 element) {
     int ret = -1;
     if (rb_is_full(rb)) {
         ret = rb_remove(rb);
@@ -198,7 +191,7 @@ static inline int rb_push_insert(ring_buffer *rb, uint8 element) {
  * @param rb Ring buffer to discard all items from.
  */
 static inline void rb_reset(ring_buffer *rb) {
-    rb->tail = rb->head;
+    rb->used=0;
 }
 
 #ifdef __cplusplus

--- a/STM32F1/system/libmaple/include/libmaple/ring_buffer.h
+++ b/STM32F1/system/libmaple/include/libmaple/ring_buffer.h
@@ -65,15 +65,22 @@ typedef struct ring_buffer {
  *
  *  @param buf  Buffer to store items into
  */
-inline void rb_init(ring_buffer *rb, uint16 size);
-/*
 static inline void rb_init(ring_buffer *rb, uint16 size, uint8 *buf) {
     rb->head = 0;
     rb->used = 0;
     rb->size = size;
     rb->buf = buf;
 }
-*/
+
+/**
+ * Initialise a ring buffer. The buffer is dynamically allocated with malloc()
+ *
+ *  @param rb   Instance to initialise
+ *
+ *  @param size Number of items in buf
+ */
+inline void rb_init_new(ring_buffer *rb, uint16 size);
+
 /**
  * @brief Return the number of elements stored in the ring buffer.
  * @param rb Buffer whose elements to count.

--- a/STM32F1/system/libmaple/include/libmaple/usart.h
+++ b/STM32F1/system/libmaple/include/libmaple/usart.h
@@ -382,7 +382,7 @@ typedef struct usart_reg_map {
 #endif
 
 #ifndef USART_TX_BUF_SIZE
-#define USART_TX_BUF_SIZE               128
+#define USART_TX_BUF_SIZE               64
 #endif
 
 /** USART device type */

--- a/STM32F1/system/libmaple/usart_private.h
+++ b/STM32F1/system/libmaple/usart_private.h
@@ -37,13 +37,14 @@
 #include <libmaple/ring_buffer.h>
 #include <libmaple/usart.h>
 
-static inline __always_inline void usart_irq(ring_buffer *rb, usart_reg_map *regs) {
-    /* We can get RXNE and ORE interrupts here. Only RXNE signifies
-     * availability of a byte in DR.
+static inline __always_inline void usart_irq(ring_buffer *rb, ring_buffer *wb, usart_reg_map *regs) {
+    /* Handling RXNEIE and TXEIE interrupts. 
+     * RXNE signifies availability of a byte in DR.
      *
      * See table 198 (sec 27.4, p809) in STM document RM0008 rev 15.
      * We enable RXNEIE. */
-    if (regs->SR & USART_SR_RXNE) {
+    int16 val;
+    if ((regs->CR1 & USART_CR1_RXNEIE) && (regs->SR & USART_SR_RXNE)) {
 #ifdef USART_SAFE_INSERT
         /* If the buffer is full and the user defines USART_SAFE_INSERT,
          * ignore new bytes. */
@@ -52,6 +53,12 @@ static inline __always_inline void usart_irq(ring_buffer *rb, usart_reg_map *reg
         /* By default, push bytes around in the ring buffer. */
         rb_push_insert(rb, (uint8)regs->DR);
 #endif
+    }
+    /* TXE signifies readiness to send a byte to DR. */
+    if ((regs->CR1 & USART_CR1_TXEIE) && (regs->SR & USART_SR_TXE)) {
+        regs->DR=rb_remove(wb);
+        if (rb_is_empty(wb))
+            regs->CR1 &= ~((uint32)USART_CR1_TXEIE); // disable TXEIE
     }
 }
 

--- a/STM32F1/system/libmaple/usart_private.h
+++ b/STM32F1/system/libmaple/usart_private.h
@@ -43,7 +43,6 @@ static inline __always_inline void usart_irq(ring_buffer *rb, ring_buffer *wb, u
      *
      * See table 198 (sec 27.4, p809) in STM document RM0008 rev 15.
      * We enable RXNEIE. */
-    int16 val;
     if ((regs->CR1 & USART_CR1_RXNEIE) && (regs->SR & USART_SR_RXNE)) {
 #ifdef USART_SAFE_INSERT
         /* If the buffer is full and the user defines USART_SAFE_INSERT,


### PR DESCRIPTION
- added buffered-interrupt based TX
- buffers can be dynamically allocated via HardwareSerial.begin()
       - min RX buffer size: 16
       - default RX buffer size: SERIAL_RX_BUFFER_SIZE
       - min TX buffer size: 1
       - default TX buffer size: SERIAL_TX_BUFFER_SIZE
- added HardwareSerial.enableBlockingTx()/disableBlockingTx() (blocking enabled by default)
- improved ring_buffer to support the full buffer size instead of buffer size - 1