### PR TITLE
Wire uses wrong SDA/SCL definitions

### DIFF
--- a/STM32F1/libraries/Wire/Wire.cpp
+++ b/STM32F1/libraries/Wire/Wire.cpp
@@ -190,5 +190,5 @@ TwoWire::~TwoWire() {
 }
 
 // Declare the instance that the users of the library can use
-//TwoWire Wire(SCL, SDA, SOFT_STANDARD);
-TwoWire Wire(PB6, PB7, SOFT_STANDARD);
+TwoWire Wire(SCL, SDA, SOFT_STANDARD);
+//TwoWire Wire(PB6, PB7, SOFT_STANDARD);

--- a/STM32F1/libraries/Wire/Wire.h
+++ b/STM32F1/libraries/Wire/Wire.h
@@ -47,8 +47,8 @@
  * On the Maple, let the default pins be in the same location as the Arduino
  * pins
  */
-#define SDA 19
-#define SCL 20
+#define SDA PB7
+#define SCL PB6
 
 #define SOFT_STANDARD 27
 #define SOFT_FAST 0


### PR DESCRIPTION
Related to issue #102 