### PR TITLE
Fix return value for Print::write(const void *buffer, uint32 size)

### DIFF
--- a/STM32F1/cores/maple/Print.cpp
+++ b/STM32F1/cores/maple/Print.cpp
@@ -60,6 +60,7 @@ size_t Print::write(const void *buffer, uint32 size) {
     uint8 *ch = (uint8*)buffer;
     while (size--) {
         write(*ch++);
+        n++;
     }
 	return n;
 }


### PR DESCRIPTION
Print::write(const void *buffer, uint32 size) always returns 0, which is against specification. This patch fixes it.