### PR TITLE
USB core and CDC fixes

### DIFF
--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -451,7 +451,7 @@ uint32 usb_cdcacm_rx(uint8* buf, uint32 len) {
 
     /* If all bytes have been read, re-enable the RX endpoint, which
      * was set to NAK when the current batch of bytes was received. */
-    if (n_unread_bytes <= (CDC_SERIAL_BUFFER_SIZE - USB_CDCACM_RX_EPSIZE)) {
+    if (n_unread_bytes == 0) {
         usb_set_ep_rx_count(USB_CDCACM_RX_ENDP, USB_CDCACM_RX_EPSIZE);
         usb_set_ep_rx_stat(USB_CDCACM_RX_ENDP, USB_EP_STAT_RX_VALID);
     }
@@ -567,7 +567,7 @@ static void vcomDataRxCb(void) {
 
 	n_unread_bytes += ep_rx_size;
 
-    if (n_unread_bytes <= (CDC_SERIAL_BUFFER_SIZE - USB_CDCACM_RX_EPSIZE)) {
+    if (n_unread_bytes == 0) {
         usb_set_ep_rx_count(USB_CDCACM_RX_ENDP, USB_CDCACM_RX_EPSIZE);
         usb_set_ep_rx_stat(USB_CDCACM_RX_ENDP, USB_EP_STAT_RX_VALID);
     }

--- a/STM32F1/cores/maple/libmaple/usb/usb_lib/usb_core.c
+++ b/STM32F1/cores/maple/libmaple/usb/usb_lib/usb_core.c
@@ -31,9 +31,6 @@
 #define USB_StatusIn() Send0LengthData()
 #define USB_StatusOut() vSetEPRxStatus(EP_RX_VALID)
 
-#define StatusInfo0 StatusInfo.bw.bb1 /* Reverse bb0 & bb1 */
-#define StatusInfo1 StatusInfo.bw.bb0
-
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 u16_u8 StatusInfo;
@@ -857,11 +854,11 @@ u8 Setup0_Process(void)
     pInformation->USBbmRequestType = *pBuf.b++; /* bmRequestType */
     pInformation->USBbRequest = *pBuf.b++; /* bRequest */
     pBuf.w++;  /* word not accessed because of 32 bits addressing */
-    pInformation->USBwValue = ByteSwap(*pBuf.w++); /* wValue */
+    pInformation->USBwValue = *pBuf.w++; /* wValue in Little Endian */
     pBuf.w++;  /* word not accessed because of 32 bits addressing */
-    pInformation->USBwIndex  = ByteSwap(*pBuf.w++); /* wIndex */
+    pInformation->USBwIndex  = *pBuf.w++; /* wIndex in Little Endian */
     pBuf.w++;  /* word not accessed because of 32 bits addressing */
-    pInformation->USBwLength = *pBuf.w; /* wLength */
+    pInformation->USBwLength = *pBuf.w; /* wLength in Little Endian */
   }
 
   pInformation->ControlState = SETTING_UP;

--- a/STM32F1/system/libmaple/usb/usb_lib/usb_core.h
+++ b/STM32F1/system/libmaple/usb/usb_lib/usb_core.h
@@ -101,8 +101,9 @@ typedef union
   u16 w;
   struct BW
   {
-    u8 bb1;
+    /* Little Endian */
     u8 bb0;
+	u8 bb1;
   }
   bw;
 } u16_u8;
@@ -211,6 +212,8 @@ USER_STANDARD_REQUESTS;
 #define USBwLength USBwLengths.w
 #define USBwLength0 USBwLengths.bw.bb0
 #define USBwLength1 USBwLengths.bw.bb1
+#define StatusInfo0 StatusInfo.bw.bb0
+#define StatusInfo1 StatusInfo.bw.bb1
 
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */


### PR DESCRIPTION
Various fixes for the USB core on the STM32F103. 

1. Fixed issue caused by commit [637174e63a277d3b3daa280adaa44c85bc2a5c07](https://github.com/rogerclarkmelbourne/Arduino_STM32/commit/637174e63a277d3b3daa280adaa44c85bc2a5c07) that caused issues with sending large amounts of data to the microcontroller. FIX: Revert back 2 lines of code. 

2. Added endian fix that was added to the bootloader core, but was never added to the Arduino Core. [Link here](https://github.com/leaflabs/maple-bootloader/commit/b7c8ce89331653c6d92fd7a52a43f444c8bcb739)

Discussion of these fixes can be found on the [stm32duino.com form](http://stm32duino.com/viewtopic.php?f=9&t=1451).