### PR TITLE
Fix usb_serial reading bug

### DIFF
--- a/STM32F1/cores/maple/usb_serial.cpp
+++ b/STM32F1/cores/maple/usb_serial.cpp
@@ -146,10 +146,10 @@ int USBSerial::available(void) {
 
 int USBSerial::peek(void)
 {
-    uint8 b;
-	if (usb_cdcacm_peek(&b, 1)==1)
+
+	if (usb_cdcacm_peek(&b_, 1)==1)
 	{
-		return b;
+		return b_;
 	}
 	else
 	{
@@ -160,10 +160,10 @@ int USBSerial::peek(void)
 void USBSerial::flush(void)
 {
 /*Roger Clark. Rather slow method. Need to improve this */
-    uint8 b;
+
 	while(usb_cdcacm_data_available())
 	{
-		this->read(&b, 1);
+		this->read(&b_, 1);
 	}
     return;
 }
@@ -183,19 +183,19 @@ uint32 USBSerial::read(void *buf, uint32 len) {
 
 /* Blocks forever until 1 byte is received */
 int USBSerial::read(void) {
-    uint8 b;
+
 	/*
 	    this->read(&b, 1);
     return b;
 	*/
 	
-	if (usb_cdcacm_rx(&b, 1)==0)
+	if (usb_cdcacm_rx(&b_, 1)==0)
 	{
 		return -1;
 	}
 	else
 	{
-		return b;
+		return b_;
 	}
 }
 

--- a/STM32F1/cores/maple/usb_serial.h
+++ b/STM32F1/cores/maple/usb_serial.h
@@ -71,6 +71,9 @@ public:
     uint8 getDTR();
     uint8 isConnected();
     uint8 pending();
+	
+private:
+    uint8 b_;
 };
 
 #ifdef SERIAL_USB 


### PR DESCRIPTION
I'm using maple with rosserial. But there was a strange bug that when maple reads continuous data through usb, it goes fail mode and program stop after a few minutes.

I figured out this error happens in read function in usb_serial library. After change the reading character variable to class member, the problem get solved. It would be some internal memory problem..