### PR TITLE
Fix for SREG error - with this flow sensor is working

### DIFF
--- a/STM32F1/cores/maple/wirish.h
+++ b/STM32F1/cores/maple/wirish.h
@@ -105,3 +105,27 @@ typedef unsigned int word;
 
 #endif
 
+class SREGemulation
+{
+public:
+   operator int () const __attribute__((always_inline)) {
+      uint32_t primask;
+      asm volatile("mrs %0, primask\n" : "=r" (primask)::);
+      if (primask) return 0;
+      return (1<<7);
+   }
+   inline SREGemulation & operator = (int val) __attribute__((always_inline)) {
+      if (val & (1<<7)) {
+         interrupts();
+      } else {
+         noInterrupts();
+      }
+      return *this;
+   }
+};
+extern SREGemulation SREG;
+
+inline unsigned char  digitalPinToInterrupt(unsigned char Interrupt_pin) { return Interrupt_pin; }
+
+#define sei() interrupts();
+#define cli() noInterrupts();


### PR DESCRIPTION
http://www.stm32duino.com/viewtopic.php?f=27&t=1167&sid=aba6dee79a24c8ad667381a999c4c08c

https://github.com/sekdiy/FlowMeter

Other sensors that are using SREG will probably work to. 
When tested more you can add it to F3 and F4 boards.
