### PR TITLE
"Serial" now works out-of-the-box on the USB-serial port of the Nucleo F103RB.

### DIFF
--- a/STM32F1/variants/nucleo_f103rb/board.cpp
+++ b/STM32F1/variants/nucleo_f103rb/board.cpp
@@ -253,7 +253,7 @@ MOSI alternate functions on the GPIO ports.
    DEFINE_HWSERIAL(Serial2, 2);
    DEFINE_HWSERIAL(Serial3, 3);
 #else
-   DEFINE_HWSERIAL(Serial, 3);// Use HW Serial 2 as "Serial"
-   DEFINE_HWSERIAL(Serial1, 2);
-   DEFINE_HWSERIAL(Serial2, 1);
+   DEFINE_HWSERIAL(Serial, 2);// Use USART2 as "Serial"
+   DEFINE_HWSERIAL(Serial1, 1);
+   DEFINE_HWSERIAL(Serial2, 3);
 #endif


### PR DESCRIPTION
There's no need to add or remove solder bridges.

Signed-off-by: Christoph Tack <prog.send@gmail.com>

---
The problem with the current implementation on the master branch is that standard Arduino examples like "ASCIITable" don't work like they work on Arduino Due.  You expect data to come out on the USB-serial port, but it doesn't.  You'll need to dig in the documentation to find out.

**/Arduino_STM32/STM32F1/variants/nucleo_f103rb/infos_pdf** contains nucleo_serial_mappings.pdf which describes pin mappings.  This file should be changed.    
**Nucleo_F103RB_hardware_preparation.pdf** describes how to connect another USART to the USB-serial debug port.  What's the point of connecting another USART to the USB-serial if it works out of the box with USART2?