### PR TITLE
Avoiding conditional directives that break statements

### DIFF
--- a/STM32F3/cores/maple/libmaple/stm32f3/f3_adc.c
+++ b/STM32F3/cores/maple/libmaple/stm32f3/f3_adc.c
@@ -301,11 +301,11 @@ void adc_config_gpio(const adc_dev *ignored, gpio_dev *gdev, uint8 bit) {
 }
 
 void adc_enable_single_swstart(const adc_dev *dev) {
+    int check_dev_adc = dev == ADC1;
 #if STM32_F3_LINE == STM32_F3_LINE_303
-		if ( (dev == ADC1) || (dev == ADC3) )
-#else
-		if (dev == ADC1)
+		check_dev_adc = (check_dev_adc || dev == ADC3);
 #endif
+		if (check_dev_adc)
 			adc_init(dev); /* FIXME hack needed for wirish, as master and slave ADC share the same reset register */
     adc_set_exttrig(dev, ADC_EXTTRIG_MODE_SOFTWARE);
 		adc_regulator_enable(dev);


### PR DESCRIPTION
Hello, this change is only aesthetic, it's a suggestion to avoid the use of conditional directives that break statements i think that kind of concern improve the code readability do you agree?