### PR TITLE
Fix bug in serial communication during SPI debug

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -31,7 +31,7 @@
 
 #include "SPI.h"
 
-//#define SPI_DEBUG
+#define SPI_DEBUG
 
 #include <libmaple/timer.h>
 #include <libmaple/util.h>
@@ -187,7 +187,7 @@ void SPIClass::end(void) {
 void SPIClass::setClockDivider(uint32_t clockDivider)
 {
 	#ifdef SPI_DEBUG
-	Serial.print("Clock divider set to "); Serial.println(clockDivider);
+    Serial.print("Clock divider set to "); Serial.println(clockDivider, DEC);
 	#endif
 	_currentSetting->clockDivider = clockDivider;
 	uint32 cr1 = _currentSetting->spi_d->regs->CR1 & ~(SPI_CR1_BR);
@@ -619,9 +619,6 @@ static const spi_baud_rate baud_rates[8] __FLASH__ = {
  */
 static spi_baud_rate determine_baud_rate(spi_dev *dev, uint32_t freq) {
 	uint32_t clock = 0, i;
-	#ifdef SPI_DEBUG
-	Serial.print("determine_baud_rate("); Serial.print(freq); Serial.println(")");
-	#endif
     switch (rcc_dev_clk(dev->clk_id))
     {
     	case RCC_APB2: clock = STM32_PCLK2; break; // 72 Mhz

--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -31,7 +31,7 @@
 
 #include "SPI.h"
 
-#define SPI_DEBUG
+//#define SPI_DEBUG
 
 #include <libmaple/timer.h>
 #include <libmaple/util.h>

--- a/STM32F1/variants/nucleo_f103rb/board.cpp
+++ b/STM32F1/variants/nucleo_f103rb/board.cpp
@@ -253,7 +253,7 @@ MOSI alternate functions on the GPIO ports.
    DEFINE_HWSERIAL(Serial2, 2);
    DEFINE_HWSERIAL(Serial3, 3);
 #else
-   DEFINE_HWSERIAL(Serial, 3);// Use HW Serial 2 as "Serial"
-   DEFINE_HWSERIAL(Serial1, 2);
-   DEFINE_HWSERIAL(Serial2, 1);
+   DEFINE_HWSERIAL(Serial, 2);// Use USART2 as "Serial"
+   DEFINE_HWSERIAL(Serial1, 1);
+   DEFINE_HWSERIAL(Serial2, 3);
 #endif


### PR DESCRIPTION
When enabling SPI-debugging in SPI.cpp, the code crashed.  This was because the SPI-debug functionality tried to write to the serial port when it was not opened yet.
This has been discovered using the Nucleo F103RB.

The change on STM32F1/variants/nucleo_f103rb/board.cpp was from another pull request and makes the USB virtual COM-port of the NucleF103RB function as Serial-port.