### PR TITLE
Add EEPROM.update() function

### DIFF
--- a/STM32F1/libraries/EEPROM/EEPROM.cpp
+++ b/STM32F1/libraries/EEPROM/EEPROM.cpp
@@ -522,6 +522,28 @@ uint16 EEPROMClass::write(uint16 Address, uint16 Data)
 }
 
 /**
+  * @brief  Writes/upadtes variable data in EEPROM.
+            The value is written only if differs from the one already saved at the same address.
+  * @param  VirtAddress: Variable virtual address
+  * @param  Data: 16 bit data to be written
+  * @retval Success or error status:
+  *			- EEPROM_SAME_VALUE: If new Data matches existing EEPROM Data
+  *			- FLASH_COMPLETE: on success
+  *			- EEPROM_BAD_ADDRESS: if address = 0xFFFF
+  *			- EEPROM_PAGE_FULL: if valid page is full
+  *			- EEPROM_NO_VALID_PAGE: if no valid page was found
+  *			- EEPROM_OUT_SIZE: if no empty EEPROM variables
+  *			- Flash error code: on write Flash error
+  */
+uint16 EEPROMClass::update(uint16 Address, uint16 Data)
+{
+	if (read(Address) == Data)
+		return EEPROM_SAME_VALUE;
+	else
+	    return write(Address, Data);
+}
+
+/**
   * @brief  Return number of variable
   * @retval Number of variables
   */

--- a/STM32F1/libraries/EEPROM/EEPROM.h
+++ b/STM32F1/libraries/EEPROM/EEPROM.h
@@ -47,6 +47,7 @@ enum : uint16
 	EEPROM_BAD_ADDRESS		= ((uint16)0x0082),
 	EEPROM_BAD_FLASH		= ((uint16)0x0083),
 	EEPROM_NOT_INIT			= ((uint16)0x0084),
+	EEPROM_SAME_VALUE		= ((uint16)0x0085),
 	EEPROM_NO_VALID_PAGE	= ((uint16)0x00AB)
 	};
 
@@ -67,6 +68,7 @@ public:
 	uint16 read (uint16 address);
 	uint16 read (uint16 address, uint16 *data);
 	uint16 write(uint16 address, uint16 data);
+	uint16 update(uint16 address, uint16 data);
 	uint16 count(uint16 *);
 	uint16 maxcount(void);
 


### PR DESCRIPTION
Basic EEPROM.update() function. Equivalent to original Arduino function, it checks the existing value of the address and only performs a write if the value differs from the one requested. 

Closes #248