### PR TITLE
Fix F103T compilation error: remove const

### DIFF
--- a/STM32F1/variants/generic_stm32f103t/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103t/wirish/boards.cpp
@@ -179,7 +179,7 @@ nvic_init((uint32)VECT_TAB_ADDR, 0);
 */
 }
 
-static void adc_default_config(const adc_dev *dev) {
+static void adc_default_config(adc_dev *dev) {
     adc_enable_single_swstart(dev);
     adc_set_sample_rate(dev, wirish::priv::w_adc_smp);
 }


### PR DESCRIPTION
Method adc_default_config still had the adc_dev* 'const' for F103T, but this doesn't compile.

For other boards, the 'const' was removed already.  See for example commits 0b34af3b6a29c2ea40a0005fde57f67f75829378 and
2cdbbc83390b27570c9040fc92bda6e63947f160.

Tested on Arduino IDE 1.6.13.

Compilation error message was along these lines:

    STM32F1\variants\generic_stm32f103t\wirish\boards.cpp:183:34: error: invalid conversion from 'const adc_dev*' to 'adc_dev*' [-fpermissive]
    STM32F1\system/libmaple/include/libmaple/adc.h:306:13: error:   initializing argument 1 of 'void adc_enable_single_swstart(adc_dev*)' [-fpermissive]
    STM32F1\variants\generic_stm32f103t\wirish\boards.cpp:184:53: error: invalid conversion from 'const adc_dev*' to 'adc_dev*' [-fpermissive]
    STM32F1\system/libmaple/include/libmaple/adc.h:268:6: error:   initializing argument 1 of 'void adc_set_sample_rate(adc_dev*, adc_smp_rate)' [-fpermissive]
    STM32F1\variants\generic_stm32f103t\wirish\boards.cpp: In function 'void setup_adcs()':
    STM32F1\variants\generic_stm32f103t\wirish\boards.cpp:189:35: error: invalid conversion from 'void (*)(const adc_dev*)' to 'void (*)(adc_dev*)' [-fpermissive]
    STM32F1\system/libmaple/include/libmaple/adc.h:282:13: error:   initializing argument 1 of 'void adc_foreach(void (*)(adc_dev*))' [-fpermissive]