### PR TITLE
Fix if serial

### DIFF
--- a/STM32F1/cores/maple/usb_serial.cpp
+++ b/STM32F1/cores/maple/usb_serial.cpp
@@ -186,7 +186,7 @@ uint8 USBSerial::getRTS(void) {
     return usb_cdcacm_get_rts();
 }
 
-uint8 USBSerial::operator bool() {
+USBSerial::operator bool() {
     return usb_is_connected(USBLIB) && usb_is_configured(USBLIB) && usb_cdcacm_get_dtr();
 }
 

--- a/STM32F1/cores/maple/usb_serial.cpp
+++ b/STM32F1/cores/maple/usb_serial.cpp
@@ -178,16 +178,16 @@ uint8 USBSerial::pending(void) {
     return usb_cdcacm_get_pending();
 }
 
-uint8 USBSerial::isConnected(void) {
-    return usb_is_connected(USBLIB) && usb_is_configured(USBLIB) && usb_cdcacm_get_dtr();
-}
-
 uint8 USBSerial::getDTR(void) {
     return usb_cdcacm_get_dtr();
 }
 
 uint8 USBSerial::getRTS(void) {
     return usb_cdcacm_get_rts();
+}
+
+uint8 USBSerial::operator bool() {
+    return usb_is_connected(USBLIB) && usb_is_configured(USBLIB) && usb_cdcacm_get_dtr();
 }
 
 #if BOARD_HAVE_SERIALUSB

--- a/STM32F1/cores/maple/usb_serial.h
+++ b/STM32F1/cores/maple/usb_serial.h
@@ -44,19 +44,19 @@ public:
 
     void begin(void);
 
-	// Roger Clark. Added dummy function so that existing Arduino sketches which specify baud rate will compile.
-	void begin(unsigned long);
-	void begin(unsigned long, uint8_t);
+    // Roger Clark. Added dummy function so that existing Arduino sketches which specify baud rate will compile.
+    void begin(unsigned long);
+    void begin(unsigned long, uint8_t);
     void end(void);
 
-	operator bool() { return true; } // Roger Clark. This is needed because in cardinfo.ino it does if (!Serial) . It seems to be a work around for the Leonardo that we needed to implement just to be compliant with the API
+    operator bool() { return true; } // Roger Clark. This is needed because in cardinfo.ino it does if (!Serial) . It seems to be a work around for the Leonardo that we needed to implement just to be compliant with the API
 
     virtual int available(void);// Changed to virtual
 
     uint32 read(uint8 * buf, uint32 len);
-   // uint8  read(void);
+    // uint8  read(void);
 
-	// Roger Clark. added functions to support Arduino 1.0 API
+    // Roger Clark. added functions to support Arduino 1.0 API
     virtual int peek(void);
     virtual int read(void);
     int availableForWrite(void);
@@ -74,8 +74,7 @@ public:
 };
 
 #ifdef SERIAL_USB 
-	extern USBSerial Serial;
+    extern USBSerial Serial;
 #endif
 
 #endif
-

--- a/STM32F1/cores/maple/usb_serial.h
+++ b/STM32F1/cores/maple/usb_serial.h
@@ -49,8 +49,6 @@ public:
     void begin(unsigned long, uint8_t);
     void end(void);
 
-    operator bool() { return true; } // Roger Clark. This is needed because in cardinfo.ino it does if (!Serial) . It seems to be a work around for the Leonardo that we needed to implement just to be compliant with the API
-
     virtual int available(void);// Changed to virtual
 
     uint32 read(uint8 * buf, uint32 len);
@@ -69,8 +67,20 @@ public:
 
     uint8 getRTS();
     uint8 getDTR();
-    uint8 isConnected();
     uint8 pending();
+	
+    /* SukkoPera: This is the Arduino way to check if an USB CDC serial
+     * connection is open.
+     
+     * Used for instance in cardinfo.ino.
+     */
+    operator bool();
+	
+    /* Old libmaple way to check for serial connection.
+     *
+     * Deprecated, use the above.
+     */
+    uint8 isConnected() { return (bool) *this; }
 };
 
 #ifdef SERIAL_USB 


### PR DESCRIPTION
The [Arduino API uses ```if (!Serial)```](https://www.arduino.cc/en/Serial/IfSerial) to check if a serial connection is established on USB CDC ports, like on The Leonardo/Micro or Due, while libmaple was using ```Serial.isConnected()```.

This patch switches the latter to the former and adds a (deprected) wrapper method to maintain backwards compatibility with sketches that use the libmaple interface.

(See http://www.stm32duino.com/viewtopic.php?f=28&t=117&p=26487#p26425 and subsequents posts.)