### PR TITLE
Fixed utoa() function definition

### DIFF
--- a/STM32F1/cores/maple/itoa.c
+++ b/STM32F1/cores/maple/itoa.c
@@ -121,7 +121,7 @@ extern char* ltoa( long value, char *string, int radix )
   return string;
 }
 
-extern char* utoa( unsigned long value, char *string, int radix )
+extern char* utoa( unsigned value, char *string, int radix )
 {
   return ultoa( value, string, radix ) ;
 }

--- a/STM32F1/cores/maple/itoa.c
+++ b/STM32F1/cores/maple/itoa.c
@@ -121,7 +121,7 @@ extern char* ltoa( long value, char *string, int radix )
   return string;
 }
 
-extern char* utoa( unsigned value, char *string, int radix )
+extern char* utoa( unsigned int value, char *string, int radix )
 {
   return ultoa( value, string, radix ) ;
 }

--- a/STM32F1/cores/maple/itoa.h
+++ b/STM32F1/cores/maple/itoa.h
@@ -31,7 +31,7 @@ extern void itoa( int n, char s[] ) ;
 
 extern char* itoa( int value, char *string, int radix ) ;
 extern char* ltoa( long value, char *string, int radix ) ;
-extern char* utoa( unsigned long value, char *string, int radix ) ;
+extern char* utoa( unsigned int value, char *string, int radix ) ;
 extern char* ultoa( unsigned long value, char *string, int radix ) ;
 #endif /* 0 */
 

--- a/STM32F4/cores/maple/itoa.c
+++ b/STM32F4/cores/maple/itoa.c
@@ -121,7 +121,7 @@ extern char* ltoa( long value, char *string, int radix )
   return string;
 }
 
-extern char* utoa( unsigned long value, char *string, int radix )
+extern char* utoa( unsigned value, char *string, int radix )
 {
   return ultoa( value, string, radix ) ;
 }

--- a/STM32F4/cores/maple/itoa.c
+++ b/STM32F4/cores/maple/itoa.c
@@ -121,7 +121,7 @@ extern char* ltoa( long value, char *string, int radix )
   return string;
 }
 
-extern char* utoa( unsigned value, char *string, int radix )
+extern char* utoa( unsigned int value, char *string, int radix )
 {
   return ultoa( value, string, radix ) ;
 }

--- a/STM32F4/cores/maple/itoa.h
+++ b/STM32F4/cores/maple/itoa.h
@@ -31,7 +31,7 @@ extern void itoa( int n, char s[] ) ;
 
 extern char* itoa( int value, char *string, int radix ) ;
 extern char* ltoa( long value, char *string, int radix ) ;
-extern char* utoa( unsigned long value, char *string, int radix ) ;
+extern char* utoa( unsigned int value, char *string, int radix ) ;
 extern char* ultoa( unsigned long value, char *string, int radix ) ;
 #endif /* 0 */
 


### PR DESCRIPTION
utoa accepts unsigned _long_ for some reason, while its counterpart itoa accepts _int_.

I figured this out when fixing a warning on my project, but I do not remember which one