### PR TITLE
Compiler warning fixed

### DIFF
--- a/STM32F1/cores/maple/libmaple/gpio_f1.c
+++ b/STM32F1/cores/maple/libmaple/gpio_f1.c
@@ -142,7 +142,6 @@ gpio_pin_mode gpio_get_mode(gpio_dev *dev, uint8 pin) {
     gpio_reg_map *regs = dev->regs;
     __io uint32 *cr = &regs->CRL + (pin >> 3);
     uint32 shift = (pin & 0x7) * 4;
-    uint32 tmp = *cr;
 
 	uint32 crMode = (*cr>>shift) & 0x0F;
 	


### PR DESCRIPTION
Removed unused variable (looks like a copy/paste issue)