### PR TITLE
Fixed a few STM32F1 compiler warnings..

### DIFF
--- a/STM32F1/cores/maple/libmaple/adc_f1.c
+++ b/STM32F1/cores/maple/libmaple/adc_f1.c
@@ -203,7 +203,7 @@ void adc_foreach(void (*fn)(adc_dev*)) {
 #endif
 }
 
-void adc_config_gpio(adc_dev *ignored, gpio_dev *gdev, uint8 bit) {
+void adc_config_gpio(adc_dev *ignored __attribute__((unused)), gpio_dev *gdev, uint8 bit) {
     gpio_set_mode(gdev, bit, GPIO_INPUT_ANALOG);
 }
 

--- a/STM32F1/cores/maple/libmaple/gpio_f1.c
+++ b/STM32F1/cores/maple/libmaple/gpio_f1.c
@@ -143,13 +143,13 @@ gpio_pin_mode gpio_get_mode(gpio_dev *dev, uint8 pin) {
     __io uint32 *cr = &regs->CRL + (pin >> 3);
     uint32 shift = (pin & 0x7) * 4;
 
-    uint32 crMode = (*cr>>shift) & 0x0F;
+	uint32 crMode = (*cr>>shift) & 0x0F;
 	
-    // could be pull up or pull down. Nee to check the ODR
-    if (crMode==GPIO_INPUT_PD && ((regs->ODR >> pin) & 0x01) !=0 )
-    {
-        crMode = GPIO_INPUT_PU;
-    }
+	// could be pull up or pull down. Nee to check the ODR
+	if (crMode==GPIO_INPUT_PD && ((regs->ODR >> pin) & 0x01) !=0 )
+	{
+		crMode = GPIO_INPUT_PU;
+	}
 	
     return(crMode);
 }

--- a/STM32F1/cores/maple/libmaple/gpio_f1.c
+++ b/STM32F1/cores/maple/libmaple/gpio_f1.c
@@ -142,15 +142,14 @@ gpio_pin_mode gpio_get_mode(gpio_dev *dev, uint8 pin) {
     gpio_reg_map *regs = dev->regs;
     __io uint32 *cr = &regs->CRL + (pin >> 3);
     uint32 shift = (pin & 0x7) * 4;
-    uint32 tmp = *cr;
 
-	uint32 crMode = (*cr>>shift) & 0x0F;
+    uint32 crMode = (*cr>>shift) & 0x0F;
 	
-	// could be pull up or pull down. Nee to check the ODR
-	if (crMode==GPIO_INPUT_PD && ((regs->ODR >> pin) & 0x01) !=0 )
-	{
-		crMode = GPIO_INPUT_PU;
-	}
+    // could be pull up or pull down. Nee to check the ODR
+    if (crMode==GPIO_INPUT_PD && ((regs->ODR >> pin) & 0x01) !=0 )
+    {
+        crMode = GPIO_INPUT_PU;
+    }
 	
     return(crMode);
 }

--- a/STM32F1/cores/maple/libmaple/rcc.c
+++ b/STM32F1/cores/maple/libmaple/rcc.c
@@ -61,7 +61,7 @@ void rcc_switch_sysclk(rcc_sysclk_src sysclk_src) {
     RCC_BASE->CFGR = cfgr;
 
     /* Wait for new source to come into use. */
-    while ((RCC_BASE->CFGR & RCC_CFGR_SWS) != (sysclk_src << 2))
+    while ((RCC_BASE->CFGR & RCC_CFGR_SWS) != (((uint32)sysclk_src) << 2))
         ;
 }
 

--- a/STM32F1/cores/maple/libmaple/spi_f1.c
+++ b/STM32F1/cores/maple/libmaple/spi_f1.c
@@ -54,7 +54,7 @@ spi_dev *SPI3 = &spi3;
  * Routines
  */
 
-void spi_config_gpios(spi_dev *ignored,
+void spi_config_gpios(spi_dev *ignored __attribute__((unused)),
                       uint8 as_master,
                       gpio_dev *nss_dev,
                       uint8 nss_bit,

--- a/STM32F1/cores/maple/libmaple/timer.c
+++ b/STM32F1/cores/maple/libmaple/timer.c
@@ -327,7 +327,7 @@ static void output_compare_mode(timer_dev *dev, uint8 channel) {
 }
 
 //added by CARLOS.
-static void encoder_mode(timer_dev *dev, uint8 channel) {
+static void encoder_mode(timer_dev *dev, uint8 channel __attribute__((unused))) {
     
     //prescaler. 
     //(dev->regs).gen->PSC = 1;

--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -409,30 +409,28 @@ void usb_cdcacm_putc(char ch) {
  * buffer, and returns the number of bytes copied. */
 uint32 usb_cdcacm_tx(const uint8* buf, uint32 len)
 {
-    if (len==0) return 0; // no data to send
+	if (len==0) return 0; // no data to send
 
-    uint32 head = tx_head; // load volatile variable
-    uint32 tx_unsent = (head - tx_tail) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
+	uint32 head = tx_head; // load volatile variable
+	uint32 tx_unsent = (head - tx_tail) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
 
     // We can only put bytes in the buffer if there is place
     if (len > (CDC_SERIAL_TX_BUFFER_SIZE-tx_unsent-1) ) {
         len = (CDC_SERIAL_TX_BUFFER_SIZE-tx_unsent-1);
     }
-    if (len==0) return 0; // buffer full
+	if (len==0) return 0; // buffer full
 
-    {
-        // copy data from user buffer to USB Tx buffer
-        uint16 i;
-        for (i=0; i<len; i++) {
-            vcomBufferTx[head] = buf[i];
-            head = (head+1) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
-        }
-    }
-    tx_head = head; // store volatile variable
+	uint16 i;
+	// copy data from user buffer to USB Tx buffer
+	for (i=0; i<len; i++) {
+		vcomBufferTx[head] = buf[i];
+		head = (head+1) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
+	}
+	tx_head = head; // store volatile variable
 
-    if (transmitting<0) {
-        vcomDataTxCb(); // initiate data transmission
-    }
+	if (transmitting<0) {
+		vcomDataTxCb(); // initiate data transmission
+	}
 
     return len;
 }
@@ -461,15 +459,15 @@ uint32 usb_cdcacm_rx(uint8* buf, uint32 len)
     uint32 n_copied = usb_cdcacm_peek(buf, len);
 
     /* Mark bytes as read. */
-    uint16 tail = rx_tail; // load volatile variable
-    tail = (tail + n_copied) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
-    rx_tail = tail; // store volatile variable
+	uint16 tail = rx_tail; // load volatile variable
+	tail = (tail + n_copied) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	rx_tail = tail; // store volatile variable
 
-    uint32 rx_unread = (rx_head - tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	uint32 rx_unread = (rx_head - tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
     // If buffer was emptied to a pre-set value, re-enable the RX endpoint
     if ( rx_unread <= 64 ) { // experimental value, gives the best performance
         usb_set_ep_rx_stat(USB_CDCACM_RX_ENDP, USB_EP_STAT_RX_VALID);
-    }
+	}
     return n_copied;
 }
 
@@ -478,36 +476,35 @@ uint32 usb_cdcacm_rx(uint8* buf, uint32 len)
  * Looks at unread bytes without marking them as read. */
 uint32 usb_cdcacm_peek(uint8* buf, uint32 len)
 {
+    uint32 i;
     uint32 tail = rx_tail;
-    uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len > rx_unread) {
         len = rx_unread;
     }
-    {
-        uint32 i;
-        for (i = 0; i < len; i++) {
-            buf[i] = vcomBufferRx[tail];
-            tail = (tail + 1) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
-        }
+
+    for (i = 0; i < len; i++) {
+        buf[i] = vcomBufferRx[tail];
+        tail = (tail + 1) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
     }
+
     return len;
 }
 
 uint32 usb_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
+    uint32 i;
     uint32 tail = (rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
-    uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len + offset > rx_unread) {
         len = rx_unread - offset;
     }
-    {
-        uint32 i;
-        for (i = 0; i < len; i++) {
-            buf[i] = vcomBufferRx[tail];
-            tail = (tail + 1) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
-        }
+
+    for (i = 0; i < len; i++) {
+        buf[i] = vcomBufferRx[tail];
+        tail = (tail + 1) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
     }
 
     return len;
@@ -516,8 +513,9 @@ uint32 usb_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 /* Roger Clark. Added. for Arduino 1.0 API support of Serial.peek() */
 int usb_cdcacm_peek_char() 
 {
-    if (usb_cdcacm_data_available() == 0) {
-        return -1;
+    if (usb_cdcacm_data_available() == 0) 
+	{
+		return -1;
     }
 
     return vcomBufferRx[rx_tail];
@@ -559,39 +557,37 @@ int usb_cdcacm_get_n_data_bits(void) {
  */
 static void vcomDataTxCb(void)
 {
-    uint32 tail = tx_tail; // load volatile variable
-    uint32 tx_unsent = (tx_head - tail) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
-    if (tx_unsent==0) {
-        if ( (--transmitting)==0) goto flush; // no more data to send
-        return; // it was already flushed, keep Tx endpoint disabled
-    }
-    transmitting = 1;
+	uint32 tail = tx_tail; // load volatile variable
+	uint32 tx_unsent = (tx_head - tail) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
+	if (tx_unsent==0) {
+		if ( (--transmitting)==0) goto flush; // no more data to send
+		return; // it was already flushed, keep Tx endpoint disabled
+	}
+	transmitting = 1;
     // We can only send up to USB_CDCACM_TX_EPSIZE bytes in the endpoint.
     if (tx_unsent > USB_CDCACM_TX_EPSIZE) {
         tx_unsent = USB_CDCACM_TX_EPSIZE;
     }
-    // copy the bytes from USB Tx buffer to PMA buffer
-    uint32 *dst = usb_pma_ptr(USB_CDCACM_TX_ADDR);
+	// copy the bytes from USB Tx buffer to PMA buffer
+	uint32 *dst = usb_pma_ptr(USB_CDCACM_TX_ADDR);
     uint16 tmp = 0;
-    uint16 val;
-    {
-        uint32 i;
-        for ( i = 0; i < tx_unsent; i++) {
-            val = vcomBufferTx[tail];
-            tail = (tail + 1) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
-            if (i&1) {
-                *dst++ = tmp | (val<<8);
-            } else {
-                tmp = val;
-            }
-        }
-    }
+	uint16 val;
+	uint32 i;
+	for (i = 0; i < tx_unsent; i++) {
+		val = vcomBufferTx[tail];
+		tail = (tail + 1) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;
+		if (i&1) {
+			*dst++ = tmp | (val<<8);
+		} else {
+			tmp = val;
+		}
+	}
     if ( tx_unsent&1 ) {
         *dst = tmp;
     }
-    tx_tail = tail; // store volatile variable
+	tx_tail = tail; // store volatile variable
 flush:
-    // enable Tx endpoint
+	// enable Tx endpoint
     usb_set_ep_tx_count(USB_CDCACM_TX_ENDP, tx_unsent);
     usb_set_ep_tx_stat(USB_CDCACM_TX_ENDP, USB_EP_STAT_TX_VALID);
 }
@@ -599,34 +595,32 @@ flush:
 
 static void vcomDataRxCb(void)
 {
-    uint32 head = rx_head; // load volatile variable
+	uint32 head = rx_head; // load volatile variable
 
-    uint32 ep_rx_size = usb_get_ep_rx_count(USB_CDCACM_RX_ENDP);
-    // This copy won't overwrite unread bytes as long as there is
-    // enough room in the USB Rx buffer for next packet
-    uint32 *src = usb_pma_ptr(USB_CDCACM_RX_ADDR);
+	uint32 ep_rx_size = usb_get_ep_rx_count(USB_CDCACM_RX_ENDP);
+	// This copy won't overwrite unread bytes as long as there is 
+	// enough room in the USB Rx buffer for next packet
+	uint32 *src = usb_pma_ptr(USB_CDCACM_RX_ADDR);
     uint16 tmp = 0;
-    uint8 val;
-    {
-        uint32 i;
-        for (i = 0; i < ep_rx_size; i++) {
-            if (i&1) {
-                val = tmp>>8;
-            } else {
-                tmp = *src++;
-                val = tmp&0xFF;
-            }
-            vcomBufferRx[head] = val;
-            head = (head + 1) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
-        }
-    }
-    rx_head = head; // store volatile variable
+	uint8 val;
+	uint32 i;
+	for (i = 0; i < ep_rx_size; i++) {
+		if (i&1) {
+			val = tmp>>8;
+		} else {
+			tmp = *src++;
+			val = tmp&0xFF;
+		}
+		vcomBufferRx[head] = val;
+		head = (head + 1) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	}
+	rx_head = head; // store volatile variable
 
-    uint32 rx_unread = (head - rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
-    // only enable further Rx if there is enough room to receive one more packet
-    if ( rx_unread < (CDC_SERIAL_RX_BUFFER_SIZE-USB_CDCACM_RX_EPSIZE) ) {
-        usb_set_ep_rx_stat(USB_CDCACM_RX_ENDP, USB_EP_STAT_RX_VALID);
-    }
+	uint32 rx_unread = (head - rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	// only enable further Rx if there is enough room to receive one more packet
+	if ( rx_unread < (CDC_SERIAL_RX_BUFFER_SIZE-USB_CDCACM_RX_EPSIZE) ) {
+		usb_set_ep_rx_stat(USB_CDCACM_RX_ENDP, USB_EP_STAT_RX_VALID);
+	}
 
     if (rx_hook) {
         rx_hook(USB_CDCACM_HOOK_RX, 0);
@@ -704,10 +698,10 @@ static void usbReset(void) {
     SetDeviceAddress(0);
 
     /* Reset the RX/TX state */
-    rx_head = 0;
-    rx_tail = 0;
-    tx_head = 0;
-    tx_tail = 0;
+	rx_head = 0;
+	rx_tail = 0;
+	tx_head = 0;
+	tx_tail = 0;
     transmitting = -1;
 }
 

--- a/STM32F1/cores/maple/libmaple/util.c
+++ b/STM32F1/cores/maple/libmaple/util.c
@@ -88,7 +88,7 @@ void _fail(const char* file, int line, const char* exp) {
  * Provide an __assert_func handler to libc so that calls to assert()
  * get redirected to _fail.
  */
-void __assert_func(const char* file, int line, const char* method,
+void __assert_func(const char* file, int line, const char* method __attribute__((unused)),
                    const char* expression) {
     _fail(file, line, expression);
 }

--- a/STM32F1/cores/maple/stm32f1/wiring_pulse_f1.cpp
+++ b/STM32F1/cores/maple/stm32f1/wiring_pulse_f1.cpp
@@ -26,14 +26,14 @@
   * to be slighly more accurate the maxLoops variable really needs to take into account the loop setup code, but its probably as good as necessary
   *
   */
-uint32_t pulseIn( uint32_t pin, uint32_t state, uint32_t timeout )
+uint32_t pulseIn( uint32_t pin, uint32_t state __attribute__((unused)), uint32_t timeout )
 {
    // cache the port and bit of the pin in order to speed up the
    // pulse width measuring loop and achieve finer resolution.  calling
    // digitalRead() instead yields much coarser resolution.
  
-	gpio_dev *dev=PIN_MAP[pin].gpio_device;
-	uint32_t bit = (1U << PIN_MAP[pin].gpio_bit);
+   gpio_dev *dev=PIN_MAP[pin].gpio_device;
+   uint32_t bit = (1U << PIN_MAP[pin].gpio_bit);
    
 
    uint32_t width = 0; // keep initialization out of time critical area

--- a/STM32F1/cores/maple/stm32f1/wiring_pulse_f1.cpp
+++ b/STM32F1/cores/maple/stm32f1/wiring_pulse_f1.cpp
@@ -32,8 +32,8 @@ uint32_t pulseIn( uint32_t pin, uint32_t state __attribute__((unused)), uint32_t
    // pulse width measuring loop and achieve finer resolution.  calling
    // digitalRead() instead yields much coarser resolution.
  
-   gpio_dev *dev=PIN_MAP[pin].gpio_device;
-   uint32_t bit = (1U << PIN_MAP[pin].gpio_bit);
+	gpio_dev *dev=PIN_MAP[pin].gpio_device;
+	uint32_t bit = (1U << PIN_MAP[pin].gpio_bit);
    
 
    uint32_t width = 0; // keep initialization out of time critical area

--- a/STM32F1/cores/maple/usb_serial.cpp
+++ b/STM32F1/cores/maple/usb_serial.cpp
@@ -211,7 +211,7 @@ enum reset_state_t {
 
 static reset_state_t reset_state = DTR_UNSET;
 
-static void ifaceSetupHook(unsigned hook, void *requestvp) {
+static void ifaceSetupHook(unsigned hook __attribute__((unused)), void *requestvp) {
     uint8 request = *(uint8*)requestvp;
 
     // Ignore requests we're not interested in.
@@ -265,7 +265,7 @@ static void wait_reset(void) {
 #define STACK_TOP 0x20000800
 #define EXC_RETURN 0xFFFFFFF9
 #define DEFAULT_CPSR 0x61000000
-static void rxHook(unsigned hook, void *ignored) {
+static void rxHook(unsigned hook __attribute__((unused)), void *ignored __attribute__((unused))) {
     /* FIXME this is mad buggy; we need a new reset sequence. E.g. NAK
      * after each RX means you can't reset if any bytes are waiting. */
     if (reset_state == DTR_NEGEDGE) {

--- a/STM32F1/libraries/Wire/HardWire.cpp
+++ b/STM32F1/libraries/Wire/HardWire.cpp
@@ -72,6 +72,6 @@ HardWire::~HardWire() {
     sel_hard = 0;
 }
 
-void HardWire::begin(uint8 self_addr) {
+void HardWire::begin(uint8 self_addr __attribute__((unused))) {
     i2c_master_enable(sel_hard, dev_flags);
 }

--- a/STM32F1/libraries/Wire/Wire.cpp
+++ b/STM32F1/libraries/Wire/Wire.cpp
@@ -173,7 +173,7 @@ TwoWire::TwoWire(uint8 scl, uint8 sda, uint8 delay) : i2c_delay(delay) {
     this->sda_pin=sda;
 }
 
-void TwoWire::begin(uint8 self_addr) {
+void TwoWire::begin(uint8 self_addr __attribute__((unused))) {
     tx_buf_idx = 0;
     tx_buf_overflow = false;
     rx_buf_idx = 0;

--- a/STM32F1/libraries/Wire/WireBase.cpp
+++ b/STM32F1/libraries/Wire/WireBase.cpp
@@ -41,7 +41,7 @@
 #include "WireBase.h"
 #include "wirish.h"
 
-void WireBase::begin(uint8 self_addr) {
+void WireBase::begin(uint8 self_addr __attribute__((unused))) {
     tx_buf_idx = 0;
     tx_buf_overflow = false;
     rx_buf_idx = 0;

--- a/STM32F1/system/libmaple/stm32f1/include/series/i2c.h
+++ b/STM32F1/system/libmaple/stm32f1/include/series/i2c.h
@@ -59,7 +59,7 @@ extern i2c_dev* const I2C2;
  * For internal use
  */
 
-static inline uint32 _i2c_bus_clk(i2c_dev *dev) {
+static inline uint32 _i2c_bus_clk(i2c_dev *dev __attribute__((unused))) {
     /* Both I2C peripherals are on APB1 */
     return STM32_PCLK1 / (1000 * 1000);
 }

--- a/STM32F1/variants/maple_mini/board.cpp
+++ b/STM32F1/variants/maple_mini/board.cpp
@@ -50,6 +50,9 @@ void boardInit(void) {
 #endif
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 extern const stm32_pin_info PIN_MAP[BOARD_NR_GPIO_PINS] = {
 
     /* Top header */
@@ -92,6 +95,8 @@ extern const stm32_pin_info PIN_MAP[BOARD_NR_GPIO_PINS] = {
     {&gpiob, &timer4, NULL,  8, 3, ADCx}, /* D32/PB8 */
     {&gpiob, &timer3, &adc1,  1, 4,    9}, /* D33/PB1 */
 };
+
+#pragma GCC diagnostic pop
 
 extern const uint8 boardPWMPins[BOARD_NR_PWM_PINS] __FLASH__ = {
     3, 4, 5, 8, 9, 10, 11, 15, 16, 25, 26, 27

--- a/STM32F1/variants/maple_mini/wirish/syscalls.c
+++ b/STM32F1/variants/maple_mini/wirish/syscalls.c
@@ -76,28 +76,28 @@ void *_sbrk(int incr) {
     return ret;
 }
 
-__weak int _open(const char *path, int flags, ...) {
+__weak int _open(const char *path __attribute__((unused)), int flags __attribute__((unused)), ...) {
     return 1;
 }
 
-__weak int _close(int fd) {
+__weak int _close(int fd __attribute__((unused))) {
     return 0;
 }
 
-__weak int _fstat(int fd, struct stat *st) {
+__weak int _fstat(int fd __attribute__((unused)), struct stat *st) {
     st->st_mode = S_IFCHR;
     return 0;
 }
 
-__weak int _isatty(int fd) {
+__weak int _isatty(int fd __attribute__((unused))) {
     return 1;
 }
 
-__weak int isatty(int fd) {
+__weak int isatty(int fd __attribute__((unused))) {
     return 1;
 }
 
-__weak int _lseek(int fd, off_t pos, int whence) {
+__weak int _lseek(int fd __attribute__((unused)), off_t pos __attribute__((unused)), int whence __attribute__((unused))) {
     return -1;
 }
 
@@ -106,13 +106,13 @@ __weak unsigned char getch(void) {
 }
 
 
-__weak int _read(int fd, char *buf, size_t cnt) {
+__weak int _read(int fd __attribute__((unused)), char *buf __attribute__((unused)), size_t cnt __attribute__((unused))) {
     *buf = getch();
 
     return 1;
 }
 
-__weak void putch(unsigned char c) {
+__weak void putch(unsigned char c __attribute__((unused))) {
 }
 
 __weak void cgets(char *s, int bufsize) {
@@ -155,8 +155,8 @@ __weak void cgets(char *s, int bufsize) {
     return;
 }
 
-__weak int _write(int fd, const char *buf, size_t cnt) {
-    int i;
+__weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
+    unsigned int i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);
@@ -165,12 +165,12 @@ __weak int _write(int fd, const char *buf, size_t cnt) {
 }
 
 /* Override fgets() in newlib with a version that does line editing */
-__weak char *fgets(char *s, int bufsize, void *f) {
+__weak char *fgets(char *s, int bufsize, void *f __attribute__((unused))) {
     cgets(s, bufsize);
     return s;
 }
 
-__weak void _exit(int exitcode) {
+__weak void _exit(int exitcode __attribute__((unused))) {
     while (1)
         ;
 }


### PR DESCRIPTION
..by adding gcc specific tags e.g. `__attribute__((unused))`
~~Also replaced tab with spaces in some files.~~
