### PR TITLE
The ssd1306_128x64_i2c_STM32 example would not build…

### DIFF
--- a/STM32F1/libraries/Adafruit_SSD1306/Adafruit_SSD1306_STM32.cpp
+++ b/STM32F1/libraries/Adafruit_SSD1306/Adafruit_SSD1306_STM32.cpp
@@ -29,6 +29,10 @@ HardWire HWIRE(2,I2C_FAST_MODE); // I2c2
 #include "Adafruit_GFX.h"
 #include "Adafruit_SSD1306_STM32.h"
 
+#ifndef swap
+#define swap(a, b) { int16_t t = a; a = b; b = t; }
+#endif
+
 // the memory buffer for the LCD
 
 static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = { 


### PR DESCRIPTION
..because of a missing swap() macro. 

I copied this macro from upstream Adafruit_GFX.h

Tested on maple mini.