### PR TITLE
Maple mini was missing BOARD_BUTTON_PIN

### DIFF
--- a/STM32F1/variants/maple_mini/board/board.h
+++ b/STM32F1/variants/maple_mini/board/board.h
@@ -71,6 +71,8 @@
 #define BOARD_USB_DISC_DEV        GPIOB
 #define BOARD_USB_DISC_BIT        9
 
+#define BOARD_BUTTON_PIN          PB8
+
 enum {
     PB11, PB10, PB2, PB0, PA7, PA6, PA5, PA4, PA3, PA2, PA1, PA0, PC15, PC14,
     PC13, PB7, PB6, PB5, PB4, PB3, PA15, PA14, PA13, PA12, PA11, PA10, PA9,


### PR DESCRIPTION
This will make the examples WhileStatementConditional, QASlave, InteractiveTest, Button, StateChangeDetection, StateChangeDetection and Debounce compile w/o any modifications on maple mini.

So far i've compiled all of the examples and tested Button, StateChangeDetection & Debounce on maple mini.

