### PR TITLE
Pinmode timer

### DIFF
--- a/STM32F1/cores/maple/stm32f1/wirish_digital_f1.cpp
+++ b/STM32F1/cores/maple/stm32f1/wirish_digital_f1.cpp
@@ -79,10 +79,14 @@ void pinMode(uint8 pin, WiringPinMode mode) {
 
     gpio_set_mode(PIN_MAP[pin].gpio_device, PIN_MAP[pin].gpio_bit, outputMode);
 
-    if (pwm && PIN_MAP[pin].timer_device != NULL) {
-        /* Enable/disable timer channels if we're switching into PWM. */
+    if (PIN_MAP[pin].timer_device != NULL) {
+        if ( pwm ) { // we're switching into PWM, enable timer channels
         timer_set_mode(PIN_MAP[pin].timer_device,
                        PIN_MAP[pin].timer_channel,
                        TIMER_PWM );
+        } else {  // disable channel output in non pwm-Mode             
+            timer_cc_disable(PIN_MAP[pin].timer_device, 
+                            PIN_MAP[pin].timer_channel); 
+        }
     }
 }

--- a/STM32F1/cores/maple/stm32f1/wirish_digital_f1.cpp
+++ b/STM32F1/cores/maple/stm32f1/wirish_digital_f1.cpp
@@ -79,11 +79,10 @@ void pinMode(uint8 pin, WiringPinMode mode) {
 
     gpio_set_mode(PIN_MAP[pin].gpio_device, PIN_MAP[pin].gpio_bit, outputMode);
 
-    if (PIN_MAP[pin].timer_device != NULL) {
-        /* Enable/disable timer channels if we're switching into or
-         * out of PWM. */
+    if (pwm && PIN_MAP[pin].timer_device != NULL) {
+        /* Enable/disable timer channels if we're switching into PWM. */
         timer_set_mode(PIN_MAP[pin].timer_device,
                        PIN_MAP[pin].timer_channel,
-                       pwm ? TIMER_PWM : TIMER_DISABLED);
+                       TIMER_PWM );
     }
 }


### PR DESCRIPTION
Hi,
as I mentioned in the forum [http://www.stm32duino.com/viewtopic.php?f=49&t=2079](url), the pinMode() function disables timer IRQs if setting non pwm modes on pwm capable pins. 
This little fix prevents this. It disconnects the timer from the pin, but leaves all other timer configurations as they are.