### PR TITLE
Fix documentation for usart_putc()

### DIFF
--- a/STM32F1/system/libmaple/include/libmaple/usart.h
+++ b/STM32F1/system/libmaple/include/libmaple/usart.h
@@ -439,8 +439,8 @@ static inline void usart_disable_all(void) {
 /**
  * @brief Transmit one character on a serial port.
  *
- * This function blocks until the character has been successfully
- * transmitted.
+ * This function blocks until the character has been queued
+ * for transmission.
  *
  * @param dev Serial port to send on.
  * @param byte Byte to transmit.


### PR DESCRIPTION
See discussion at https://github.com/rogerclarkmelbourne/Arduino_STM32/pull/260

usart_putc() blocks until space is available in the ring buffer, not until the character has been transmitted.