### PR TITLE
Avoid initializing USB serial twice

### DIFF
--- a/STM32F1/cores/maple/usb_serial.cpp
+++ b/STM32F1/cores/maple/usb_serial.cpp
@@ -55,6 +55,7 @@ static void ifaceSetupHook(unsigned, void*);
 
 #define USB_TIMEOUT 50
 
+bool USBSerial::_hasBegun = false;
 USBSerial::USBSerial(void) {
 #if !BOARD_HAVE_SERIALUSB
     ASSERT(0);
@@ -62,6 +63,9 @@ USBSerial::USBSerial(void) {
 }
 
 void USBSerial::begin(void) {
+    if (_hasBegun)
+        return;
+    _hasBegun = true;
 #if BOARD_HAVE_SERIALUSB
     usb_cdcacm_enable(BOARD_USB_DISC_DEV, BOARD_USB_DISC_BIT);
     usb_cdcacm_set_hooks(USB_CDCACM_HOOK_RX, rxHook);
@@ -90,6 +94,7 @@ void USBSerial::end(void) {
     usb_cdcacm_disable(BOARD_USB_DISC_DEV, BOARD_USB_DISC_BIT);
     usb_cdcacm_remove_hooks(USB_CDCACM_HOOK_RX | USB_CDCACM_HOOK_IFACE_SETUP);
 #endif
+    _hasBegun = false;
 }
 
 size_t USBSerial::write(uint8 ch) {

--- a/STM32F1/cores/maple/usb_serial.h
+++ b/STM32F1/cores/maple/usb_serial.h
@@ -71,6 +71,9 @@ public:
     uint8 getDTR();
     uint8 isConnected();
     uint8 pending();
+
+protected:
+    static bool _hasBegun;
 };
 
 #ifdef SERIAL_USB 


### PR DESCRIPTION
This patch avoid initializing the USB serial HW of F103C twice in the bootstrapping process. It may hangup if you initialize the HW while the USB serial port is using by host.

Please refer to discussion in the topic " USB Observations" at  http://stm32duino.com/viewtopic.php?f=28&t=2107

There is another patch which will fix this problem also.
http://stm32duino.com/viewtopic.php?f=28&t=2107&start=80#p29087