### PR TITLE
Mtiutiu/compiler opts menus

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -4,6 +4,7 @@ menu.device_variant=Variant
 menu.bootloader_version=Bootloader version
 menu.upload_method=Upload method
 menu.cpu_speed=CPU Speed(MHz)
+menu.opt=Optimize
 
 ##############################################################
 mapleMini.name=Maple Mini
@@ -43,6 +44,38 @@ mapleMini.menu.cpu_speed.speed_72mhz.build.f_cpu=72000000L
 mapleMini.menu.cpu_speed.speed_48mhz=48Mhz (Slow - with USB)
 mapleMini.menu.cpu_speed.speed_48mhz.build.f_cpu=48000000L
 
+#-- Optimizations
+mapleMini.menu.opt.o2std=Faster
+mapleMini.menu.opt.o2std.build.flags.optimize=-O2
+mapleMini.menu.opt.o2std.build.flags.ldspecs=
+mapleMini.menu.opt.o2lto=Faster with LTO
+mapleMini.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+mapleMini.menu.opt.o2lto.build.flags.ldspecs=-flto
+mapleMini.menu.opt.o1std=Fast
+mapleMini.menu.opt.o1std.build.flags.optimize=-O1
+mapleMini.menu.opt.o1std.build.flags.ldspecs=
+mapleMini.menu.opt.o1lto=Fast with LTO
+mapleMini.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+mapleMini.menu.opt.o1lto.build.flags.ldspecs=-flto
+mapleMini.menu.opt.o3std=Fastest
+mapleMini.menu.opt.o3std.build.flags.optimize=-O3
+mapleMini.menu.opt.o3std.build.flags.ldspecs=
+mapleMini.menu.opt.o3lto=Fastest with LTO
+mapleMini.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+mapleMini.menu.opt.o3lto.build.flags.ldspecs=-flto
+mapleMini.menu.opt.ogstd=Debug
+mapleMini.menu.opt.ogstd.build.flags.optimize=-Og
+mapleMini.menu.opt.ogstd.build.flags.ldspecs=
+mapleMini.menu.opt.oglto=Debug with LTO
+mapleMini.menu.opt.oglto.build.flags.optimize=-Og -flto
+mapleMini.menu.opt.oglto.build.flags.ldspecs=-flto
+mapleMini.menu.opt.osstd=Smallest Code
+mapleMini.menu.opt.osstd.build.flags.optimize=-Os
+mapleMini.menu.opt.osstd.build.flags.ldspecs=
+mapleMini.menu.opt.oslto=Smallest Code with LTO
+mapleMini.menu.opt.oslto.build.flags.optimize=-Os -flto
+mapleMini.menu.opt.oslto.build.flags.ldspecs=-flto
+
 
 ##############################################################
 maple.name=Maple (Rev 3)
@@ -66,6 +99,38 @@ maple.build.ldscript=ld/flash.ld
 maple.build.variant=maple
 maple.build.vect=VECT_TAB_ADDR=0x8005000
 
+#-- Optimizations
+maple.menu.opt.o2std=Faster
+maple.menu.opt.o2std.build.flags.optimize=-O2
+maple.menu.opt.o2std.build.flags.ldspecs=
+maple.menu.opt.o2lto=Faster with LTO
+maple.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+maple.menu.opt.o2lto.build.flags.ldspecs=-flto
+maple.menu.opt.o1std=Fast
+maple.menu.opt.o1std.build.flags.optimize=-O1
+maple.menu.opt.o1std.build.flags.ldspecs=
+maple.menu.opt.o1lto=Fast with LTO
+maple.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+maple.menu.opt.o1lto.build.flags.ldspecs=-flto
+maple.menu.opt.o3std=Fastest
+maple.menu.opt.o3std.build.flags.optimize=-O3
+maple.menu.opt.o3std.build.flags.ldspecs=
+maple.menu.opt.o3lto=Fastest with LTO
+maple.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+maple.menu.opt.o3lto.build.flags.ldspecs=-flto
+maple.menu.opt.ogstd=Debug
+maple.menu.opt.ogstd.build.flags.optimize=-Og
+maple.menu.opt.ogstd.build.flags.ldspecs=
+maple.menu.opt.oglto=Debug with LTO
+maple.menu.opt.oglto.build.flags.optimize=-Og -flto
+maple.menu.opt.oglto.build.flags.ldspecs=-flto
+maple.menu.opt.osstd=Smallest Code
+maple.menu.opt.osstd.build.flags.optimize=-Os
+maple.menu.opt.osstd.build.flags.ldspecs=
+maple.menu.opt.oslto=Smallest Code with LTO
+maple.menu.opt.oslto.build.flags.optimize=-Os -flto
+maple.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ##############################################################
 mapleRET6.name=Maple (RET6)
 
@@ -88,6 +153,38 @@ mapleRET6.upload.file_type=bin
 mapleRET6.upload.usbID=1EAF:0003
 mapleRET6.upload.altID=1
 mapleRET6.upload.auto_reset=true
+
+#-- Optimizations
+mapleRET6.menu.opt.o2std=Faster
+mapleRET6.menu.opt.o2std.build.flags.optimize=-O2
+mapleRET6.menu.opt.o2std.build.flags.ldspecs=
+mapleRET6.menu.opt.o2lto=Faster with LTO
+mapleRET6.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+mapleRET6.menu.opt.o2lto.build.flags.ldspecs=-flto
+mapleRET6.menu.opt.o1std=Fast
+mapleRET6.menu.opt.o1std.build.flags.optimize=-O1
+mapleRET6.menu.opt.o1std.build.flags.ldspecs=
+mapleRET6.menu.opt.o1lto=Fast with LTO
+mapleRET6.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+mapleRET6.menu.opt.o1lto.build.flags.ldspecs=-flto
+mapleRET6.menu.opt.o3std=Fastest
+mapleRET6.menu.opt.o3std.build.flags.optimize=-O3
+mapleRET6.menu.opt.o3std.build.flags.ldspecs=
+mapleRET6.menu.opt.o3lto=Fastest with LTO
+mapleRET6.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+mapleRET6.menu.opt.o3lto.build.flags.ldspecs=-flto
+mapleRET6.menu.opt.ogstd=Debug
+mapleRET6.menu.opt.ogstd.build.flags.optimize=-Og
+mapleRET6.menu.opt.ogstd.build.flags.ldspecs=
+mapleRET6.menu.opt.oglto=Debug with LTO
+mapleRET6.menu.opt.oglto.build.flags.optimize=-Og -flto
+mapleRET6.menu.opt.oglto.build.flags.ldspecs=-flto
+mapleRET6.menu.opt.osstd=Smallest Code
+mapleRET6.menu.opt.osstd.build.flags.optimize=-Os
+mapleRET6.menu.opt.osstd.build.flags.ldspecs=
+mapleRET6.menu.opt.oslto=Smallest Code with LTO
+mapleRET6.menu.opt.oslto.build.flags.optimize=-Os -flto
+mapleRET6.menu.opt.oslto.build.flags.ldspecs=-flto
 
 ##############################################################
 
@@ -119,6 +216,38 @@ microduino32_flash.build.density=STM32_MEDIUM_DENSITY
 microduino32_flash.build.error_led_port=GPIOB
 microduino32_flash.build.error_led_pin=1
 microduino32_flash.build.gcc_ver=gcc-arm-none-eabi-4.8.3-2014q1
+
+#-- Optimizations
+microduino32_flash.menu.opt.o2std=Faster
+microduino32_flash.menu.opt.o2std.build.flags.optimize=-O2
+microduino32_flash.menu.opt.o2std.build.flags.ldspecs=
+microduino32_flash.menu.opt.o2lto=Faster with LTO
+microduino32_flash.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+microduino32_flash.menu.opt.o2lto.build.flags.ldspecs=-flto
+microduino32_flash.menu.opt.o1std=Fast
+microduino32_flash.menu.opt.o1std.build.flags.optimize=-O1
+microduino32_flash.menu.opt.o1std.build.flags.ldspecs=
+microduino32_flash.menu.opt.o1lto=Fast with LTO
+microduino32_flash.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+microduino32_flash.menu.opt.o1lto.build.flags.ldspecs=-flto
+microduino32_flash.menu.opt.o3std=Fastest
+microduino32_flash.menu.opt.o3std.build.flags.optimize=-O3
+microduino32_flash.menu.opt.o3std.build.flags.ldspecs=
+microduino32_flash.menu.opt.o3lto=Fastest with LTO
+microduino32_flash.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+microduino32_flash.menu.opt.o3lto.build.flags.ldspecs=-flto
+microduino32_flash.menu.opt.ogstd=Debug
+microduino32_flash.menu.opt.ogstd.build.flags.optimize=-Og
+microduino32_flash.menu.opt.ogstd.build.flags.ldspecs=
+microduino32_flash.menu.opt.oglto=Debug with LTO
+microduino32_flash.menu.opt.oglto.build.flags.optimize=-Og -flto
+microduino32_flash.menu.opt.oglto.build.flags.ldspecs=-flto
+microduino32_flash.menu.opt.osstd=Smallest Code
+microduino32_flash.menu.opt.osstd.build.flags.optimize=-Os
+microduino32_flash.menu.opt.osstd.build.flags.ldspecs=
+microduino32_flash.menu.opt.oslto=Smallest Code with LTO
+microduino32_flash.menu.opt.oslto.build.flags.optimize=-Os -flto
+microduino32_flash.menu.opt.oslto.build.flags.ldspecs=-flto
 
 ##############################################################
 nucleo_f103rb.name=STM Nucleo F103RB (STLink)
@@ -157,6 +286,38 @@ nucleo_f103rb.menu.device_variant.NucleoF103_HSI.build.extra_flags=-DMCU_STM32F1
 nucleo_f103rb.menu.device_variant.NucleoF103_HSE=Nucleo F103 @ 72 MHz w/ crystal
 nucleo_f103rb.menu.device_variant.NucleoF103_HSE.build.f_cpu=72000000L
 nucleo_f103rb.menu.device_variant.NucleoF103_HSE.build.extra_flags=-DNUCLEO_HSE_CRYSTAL -DMCU_STM32F103RB -mthumb -march=armv7-m -D__STM32F1__
+
+#-- Optimizations
+nucleo_f103rb.menu.opt.o2std=Faster
+nucleo_f103rb.menu.opt.o2std.build.flags.optimize=-O2
+nucleo_f103rb.menu.opt.o2std.build.flags.ldspecs=
+nucleo_f103rb.menu.opt.o2lto=Faster with LTO
+nucleo_f103rb.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+nucleo_f103rb.menu.opt.o2lto.build.flags.ldspecs=-flto
+nucleo_f103rb.menu.opt.o1std=Fast
+nucleo_f103rb.menu.opt.o1std.build.flags.optimize=-O1
+nucleo_f103rb.menu.opt.o1std.build.flags.ldspecs=
+nucleo_f103rb.menu.opt.o1lto=Fast with LTO
+nucleo_f103rb.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+nucleo_f103rb.menu.opt.o1lto.build.flags.ldspecs=-flto
+nucleo_f103rb.menu.opt.o3std=Fastest
+nucleo_f103rb.menu.opt.o3std.build.flags.optimize=-O3
+nucleo_f103rb.menu.opt.o3std.build.flags.ldspecs=
+nucleo_f103rb.menu.opt.o3lto=Fastest with LTO
+nucleo_f103rb.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+nucleo_f103rb.menu.opt.o3lto.build.flags.ldspecs=-flto
+nucleo_f103rb.menu.opt.ogstd=Debug
+nucleo_f103rb.menu.opt.ogstd.build.flags.optimize=-Og
+nucleo_f103rb.menu.opt.ogstd.build.flags.ldspecs=
+nucleo_f103rb.menu.opt.oglto=Debug with LTO
+nucleo_f103rb.menu.opt.oglto.build.flags.optimize=-Og -flto
+nucleo_f103rb.menu.opt.oglto.build.flags.ldspecs=-flto
+nucleo_f103rb.menu.opt.osstd=Smallest Code
+nucleo_f103rb.menu.opt.osstd.build.flags.optimize=-Os
+nucleo_f103rb.menu.opt.osstd.build.flags.ldspecs=
+nucleo_f103rb.menu.opt.oslto=Smallest Code with LTO
+nucleo_f103rb.menu.opt.oslto.build.flags.optimize=-Os -flto
+nucleo_f103rb.menu.opt.oslto.build.flags.ldspecs=-flto
 
 ###################### Generic STM32F103C ########################################
 
@@ -222,6 +383,38 @@ genericSTM32F103C.menu.cpu_speed.speed_72mhz.build.f_cpu=72000000L
 
 genericSTM32F103C.menu.cpu_speed.speed_48mhz=48Mhz (Slow - with USB)
 genericSTM32F103C.menu.cpu_speed.speed_48mhz.build.f_cpu=48000000L
+
+#-- Optimizations
+genericSTM32F103C.menu.opt.o2std=Faster
+genericSTM32F103C.menu.opt.o2std.build.flags.optimize=-O2
+genericSTM32F103C.menu.opt.o2std.build.flags.ldspecs=
+genericSTM32F103C.menu.opt.o2lto=Faster with LTO
+genericSTM32F103C.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+genericSTM32F103C.menu.opt.o2lto.build.flags.ldspecs=-flto
+genericSTM32F103C.menu.opt.o1std=Fast
+genericSTM32F103C.menu.opt.o1std.build.flags.optimize=-O1
+genericSTM32F103C.menu.opt.o1std.build.flags.ldspecs=
+genericSTM32F103C.menu.opt.o1lto=Fast with LTO
+genericSTM32F103C.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+genericSTM32F103C.menu.opt.o1lto.build.flags.ldspecs=-flto
+genericSTM32F103C.menu.opt.o3std=Fastest
+genericSTM32F103C.menu.opt.o3std.build.flags.optimize=-O3
+genericSTM32F103C.menu.opt.o3std.build.flags.ldspecs=
+genericSTM32F103C.menu.opt.o3lto=Fastest with LTO
+genericSTM32F103C.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+genericSTM32F103C.menu.opt.o3lto.build.flags.ldspecs=-flto
+genericSTM32F103C.menu.opt.ogstd=Debug
+genericSTM32F103C.menu.opt.ogstd.build.flags.optimize=-Og
+genericSTM32F103C.menu.opt.ogstd.build.flags.ldspecs=
+genericSTM32F103C.menu.opt.oglto=Debug with LTO
+genericSTM32F103C.menu.opt.oglto.build.flags.optimize=-Og -flto
+genericSTM32F103C.menu.opt.oglto.build.flags.ldspecs=-flto
+genericSTM32F103C.menu.opt.osstd=Smallest Code
+genericSTM32F103C.menu.opt.osstd.build.flags.optimize=-Os
+genericSTM32F103C.menu.opt.osstd.build.flags.ldspecs=
+genericSTM32F103C.menu.opt.oslto=Smallest Code with LTO
+genericSTM32F103C.menu.opt.oslto.build.flags.optimize=-Os -flto
+genericSTM32F103C.menu.opt.oslto.build.flags.ldspecs=-flto
 
 ########################### Generic STM32F103R ###########################
 
@@ -292,6 +485,38 @@ genericSTM32F103R.menu.upload_method.BMPMethod.upload.protocol=gdb_bmp
 genericSTM32F103R.menu.upload_method.BMPMethod.upload.tool=bmp_upload
 genericSTM32F103R.menu.upload_method.BMPMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG
 
+#-- Optimizations
+genericSTM32F103R.menu.opt.o2std=Faster
+genericSTM32F103R.menu.opt.o2std.build.flags.optimize=-O2
+genericSTM32F103R.menu.opt.o2std.build.flags.ldspecs=
+genericSTM32F103R.menu.opt.o2lto=Faster with LTO
+genericSTM32F103R.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+genericSTM32F103R.menu.opt.o2lto.build.flags.ldspecs=-flto
+genericSTM32F103R.menu.opt.o1std=Fast
+genericSTM32F103R.menu.opt.o1std.build.flags.optimize=-O1
+genericSTM32F103R.menu.opt.o1std.build.flags.ldspecs=
+genericSTM32F103R.menu.opt.o1lto=Fast with LTO
+genericSTM32F103R.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+genericSTM32F103R.menu.opt.o1lto.build.flags.ldspecs=-flto
+genericSTM32F103R.menu.opt.o3std=Fastest
+genericSTM32F103R.menu.opt.o3std.build.flags.optimize=-O3
+genericSTM32F103R.menu.opt.o3std.build.flags.ldspecs=
+genericSTM32F103R.menu.opt.o3lto=Fastest with LTO
+genericSTM32F103R.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+genericSTM32F103R.menu.opt.o3lto.build.flags.ldspecs=-flto
+genericSTM32F103R.menu.opt.ogstd=Debug
+genericSTM32F103R.menu.opt.ogstd.build.flags.optimize=-Og
+genericSTM32F103R.menu.opt.ogstd.build.flags.ldspecs=
+genericSTM32F103R.menu.opt.oglto=Debug with LTO
+genericSTM32F103R.menu.opt.oglto.build.flags.optimize=-Og -flto
+genericSTM32F103R.menu.opt.oglto.build.flags.ldspecs=-flto
+genericSTM32F103R.menu.opt.osstd=Smallest Code
+genericSTM32F103R.menu.opt.osstd.build.flags.optimize=-Os
+genericSTM32F103R.menu.opt.osstd.build.flags.ldspecs=
+genericSTM32F103R.menu.opt.oslto=Smallest Code with LTO
+genericSTM32F103R.menu.opt.oslto.build.flags.optimize=-Os -flto
+genericSTM32F103R.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ###################### Generic STM32F103T ########################################
 
 genericSTM32F103T.name=Generic STM32F103T series
@@ -344,6 +569,38 @@ genericSTM32F103T.menu.upload_method.BMPMethod=BMP (Black Magic Probe)
 genericSTM32F103T.menu.upload_method.BMPMethod.upload.protocol=gdb_bmp
 genericSTM32F103T.menu.upload_method.BMPMethod.upload.tool=bmp_upload
 genericSTM32F103T.menu.upload_method.BMPMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG
+
+#-- Optimizations
+genericSTM32F103T.menu.opt.o2std=Faster
+genericSTM32F103T.menu.opt.o2std.build.flags.optimize=-O2
+genericSTM32F103T.menu.opt.o2std.build.flags.ldspecs=
+genericSTM32F103T.menu.opt.o2lto=Faster with LTO
+genericSTM32F103T.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+genericSTM32F103T.menu.opt.o2lto.build.flags.ldspecs=-flto
+genericSTM32F103T.menu.opt.o1std=Fast
+genericSTM32F103T.menu.opt.o1std.build.flags.optimize=-O1
+genericSTM32F103T.menu.opt.o1std.build.flags.ldspecs=
+genericSTM32F103T.menu.opt.o1lto=Fast with LTO
+genericSTM32F103T.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+genericSTM32F103T.menu.opt.o1lto.build.flags.ldspecs=-flto
+genericSTM32F103T.menu.opt.o3std=Fastest
+genericSTM32F103T.menu.opt.o3std.build.flags.optimize=-O3
+genericSTM32F103T.menu.opt.o3std.build.flags.ldspecs=
+genericSTM32F103T.menu.opt.o3lto=Fastest with LTO
+genericSTM32F103T.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+genericSTM32F103T.menu.opt.o3lto.build.flags.ldspecs=-flto
+genericSTM32F103T.menu.opt.ogstd=Debug
+genericSTM32F103T.menu.opt.ogstd.build.flags.optimize=-Og
+genericSTM32F103T.menu.opt.ogstd.build.flags.ldspecs=
+genericSTM32F103T.menu.opt.oglto=Debug with LTO
+genericSTM32F103T.menu.opt.oglto.build.flags.optimize=-Og -flto
+genericSTM32F103T.menu.opt.oglto.build.flags.ldspecs=-flto
+genericSTM32F103T.menu.opt.osstd=Smallest Code
+genericSTM32F103T.menu.opt.osstd.build.flags.optimize=-Os
+genericSTM32F103T.menu.opt.osstd.build.flags.ldspecs=
+genericSTM32F103T.menu.opt.oslto=Smallest Code with LTO
+genericSTM32F103T.menu.opt.oslto.build.flags.optimize=-Os -flto
+genericSTM32F103T.menu.opt.oslto.build.flags.ldspecs=-flto
 
 ########################### Generic STM32F103V ###########################
 
@@ -405,6 +662,38 @@ genericSTM32F103V.menu.upload_method.BMPMethod.upload.protocol=gdb_bmp
 genericSTM32F103V.menu.upload_method.BMPMethod.upload.tool=bmp_upload
 genericSTM32F103V.menu.upload_method.BMPMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG
 
+#-- Optimizations
+genericSTM32F103V.menu.opt.o2std=Faster
+genericSTM32F103V.menu.opt.o2std.build.flags.optimize=-O2
+genericSTM32F103V.menu.opt.o2std.build.flags.ldspecs=
+genericSTM32F103V.menu.opt.o2lto=Faster with LTO
+genericSTM32F103V.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+genericSTM32F103V.menu.opt.o2lto.build.flags.ldspecs=-flto
+genericSTM32F103V.menu.opt.o1std=Fast
+genericSTM32F103V.menu.opt.o1std.build.flags.optimize=-O1
+genericSTM32F103V.menu.opt.o1std.build.flags.ldspecs=
+genericSTM32F103V.menu.opt.o1lto=Fast with LTO
+genericSTM32F103V.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+genericSTM32F103V.menu.opt.o1lto.build.flags.ldspecs=-flto
+genericSTM32F103V.menu.opt.o3std=Fastest
+genericSTM32F103V.menu.opt.o3std.build.flags.optimize=-O3
+genericSTM32F103V.menu.opt.o3std.build.flags.ldspecs=
+genericSTM32F103V.menu.opt.o3lto=Fastest with LTO
+genericSTM32F103V.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+genericSTM32F103V.menu.opt.o3lto.build.flags.ldspecs=-flto
+genericSTM32F103V.menu.opt.ogstd=Debug
+genericSTM32F103V.menu.opt.ogstd.build.flags.optimize=-Og
+genericSTM32F103V.menu.opt.ogstd.build.flags.ldspecs=
+genericSTM32F103V.menu.opt.oglto=Debug with LTO
+genericSTM32F103V.menu.opt.oglto.build.flags.optimize=-Og -flto
+genericSTM32F103V.menu.opt.oglto.build.flags.ldspecs=-flto
+genericSTM32F103V.menu.opt.osstd=Smallest Code
+genericSTM32F103V.menu.opt.osstd.build.flags.optimize=-Os
+genericSTM32F103V.menu.opt.osstd.build.flags.ldspecs=
+genericSTM32F103V.menu.opt.oslto=Smallest Code with LTO
+genericSTM32F103V.menu.opt.oslto.build.flags.optimize=-Os -flto
+genericSTM32F103V.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ########################### Generic STM32F103Z ###########################
 
 genericSTM32F103Z.name=Generic STM32F103Z series
@@ -462,6 +751,38 @@ genericSTM32F103Z.menu.upload_method.BMPMethod.upload.protocol=gdb_bmp
 genericSTM32F103Z.menu.upload_method.BMPMethod.upload.tool=bmp_upload
 genericSTM32F103Z.menu.upload_method.BMPMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG
 
+#-- Optimizations
+genericSTM32F103Z.menu.opt.o2std=Faster
+genericSTM32F103Z.menu.opt.o2std.build.flags.optimize=-O2
+genericSTM32F103Z.menu.opt.o2std.build.flags.ldspecs=
+genericSTM32F103Z.menu.opt.o2lto=Faster with LTO
+genericSTM32F103Z.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+genericSTM32F103Z.menu.opt.o2lto.build.flags.ldspecs=-flto
+genericSTM32F103Z.menu.opt.o1std=Fast
+genericSTM32F103Z.menu.opt.o1std.build.flags.optimize=-O1
+genericSTM32F103Z.menu.opt.o1std.build.flags.ldspecs=
+genericSTM32F103Z.menu.opt.o1lto=Fast with LTO
+genericSTM32F103Z.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+genericSTM32F103Z.menu.opt.o1lto.build.flags.ldspecs=-flto
+genericSTM32F103Z.menu.opt.o3std=Fastest
+genericSTM32F103Z.menu.opt.o3std.build.flags.optimize=-O3
+genericSTM32F103Z.menu.opt.o3std.build.flags.ldspecs=
+genericSTM32F103Z.menu.opt.o3lto=Fastest with LTO
+genericSTM32F103Z.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+genericSTM32F103Z.menu.opt.o3lto.build.flags.ldspecs=-flto
+genericSTM32F103Z.menu.opt.ogstd=Debug
+genericSTM32F103Z.menu.opt.ogstd.build.flags.optimize=-Og
+genericSTM32F103Z.menu.opt.ogstd.build.flags.ldspecs=
+genericSTM32F103Z.menu.opt.oglto=Debug with LTO
+genericSTM32F103Z.menu.opt.oglto.build.flags.optimize=-Og -flto
+genericSTM32F103Z.menu.opt.oglto.build.flags.ldspecs=-flto
+genericSTM32F103Z.menu.opt.osstd=Smallest Code
+genericSTM32F103Z.menu.opt.osstd.build.flags.optimize=-Os
+genericSTM32F103Z.menu.opt.osstd.build.flags.ldspecs=
+genericSTM32F103Z.menu.opt.oslto=Smallest Code with LTO
+genericSTM32F103Z.menu.opt.oslto.build.flags.optimize=-Os -flto
+genericSTM32F103Z.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ###################### HYTiny STM32F103T ########################################
 
 hytiny-stm32f103t.name=HYTiny STM32F103TB
@@ -513,6 +834,37 @@ hytiny-stm32f103t.menu.upload_method.jlinkMethod.upload.protocol=jlink
 hytiny-stm32f103t.menu.upload_method.jlinkMethod.upload.tool=jlink_upload
 hytiny-stm32f103t.menu.upload_method.jlinkMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DSERIAL_USB -DGENERIC_BOOTLOADER 
 
+#-- Optimizations
+hytiny-stm32f103t.menu.opt.o2std=Faster
+hytiny-stm32f103t.menu.opt.o2std.build.flags.optimize=-O2
+hytiny-stm32f103t.menu.opt.o2std.build.flags.ldspecs=
+hytiny-stm32f103t.menu.opt.o2lto=Faster with LTO
+hytiny-stm32f103t.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+hytiny-stm32f103t.menu.opt.o2lto.build.flags.ldspecs=-flto
+hytiny-stm32f103t.menu.opt.o1std=Fast
+hytiny-stm32f103t.menu.opt.o1std.build.flags.optimize=-O1
+hytiny-stm32f103t.menu.opt.o1std.build.flags.ldspecs=
+hytiny-stm32f103t.menu.opt.o1lto=Fast with LTO
+hytiny-stm32f103t.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+hytiny-stm32f103t.menu.opt.o1lto.build.flags.ldspecs=-flto
+hytiny-stm32f103t.menu.opt.o3std=Fastest
+hytiny-stm32f103t.menu.opt.o3std.build.flags.optimize=-O3
+hytiny-stm32f103t.menu.opt.o3std.build.flags.ldspecs=
+hytiny-stm32f103t.menu.opt.o3lto=Fastest with LTO
+hytiny-stm32f103t.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+hytiny-stm32f103t.menu.opt.o3lto.build.flags.ldspecs=-flto
+hytiny-stm32f103t.menu.opt.ogstd=Debug
+hytiny-stm32f103t.menu.opt.ogstd.build.flags.optimize=-Og
+hytiny-stm32f103t.menu.opt.ogstd.build.flags.ldspecs=
+hytiny-stm32f103t.menu.opt.oglto=Debug with LTO
+hytiny-stm32f103t.menu.opt.oglto.build.flags.optimize=-Og -flto
+hytiny-stm32f103t.menu.opt.oglto.build.flags.ldspecs=-flto
+hytiny-stm32f103t.menu.opt.osstd=Smallest Code
+hytiny-stm32f103t.menu.opt.osstd.build.flags.optimize=-Os
+hytiny-stm32f103t.menu.opt.osstd.build.flags.ldspecs=
+hytiny-stm32f103t.menu.opt.oslto=Smallest Code with LTO
+hytiny-stm32f103t.menu.opt.oslto.build.flags.optimize=-Os -flto
+hytiny-stm32f103t.menu.opt.oslto.build.flags.ldspecs=-flto
 
 ###################### Generic GD32F103C  ########################################
 
@@ -576,6 +928,38 @@ genericGD32F103C.menu.cpu_speed.speed_96mhz.build.f_cpu=96000000L
 genericGD32F103C.menu.cpu_speed.speed_72mhz=72Mhz (compatibility)
 genericGD32F103C.menu.cpu_speed.speed_72mhz.build.f_cpu=72000000L
 
+#-- Optimizations
+genericGD32F103C.menu.opt.o2std=Faster
+genericGD32F103C.menu.opt.o2std.build.flags.optimize=-O2
+genericGD32F103C.menu.opt.o2std.build.flags.ldspecs=
+genericGD32F103C.menu.opt.o2lto=Faster with LTO
+genericGD32F103C.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+genericGD32F103C.menu.opt.o2lto.build.flags.ldspecs=-flto
+genericGD32F103C.menu.opt.o1std=Fast
+genericGD32F103C.menu.opt.o1std.build.flags.optimize=-O1
+genericGD32F103C.menu.opt.o1std.build.flags.ldspecs=
+genericGD32F103C.menu.opt.o1lto=Fast with LTO
+genericGD32F103C.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+genericGD32F103C.menu.opt.o1lto.build.flags.ldspecs=-flto
+genericGD32F103C.menu.opt.o3std=Fastest
+genericGD32F103C.menu.opt.o3std.build.flags.optimize=-O3
+genericGD32F103C.menu.opt.o3std.build.flags.ldspecs=
+genericGD32F103C.menu.opt.o3lto=Fastest with LTO
+genericGD32F103C.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+genericGD32F103C.menu.opt.o3lto.build.flags.ldspecs=-flto
+genericGD32F103C.menu.opt.ogstd=Debug
+genericGD32F103C.menu.opt.ogstd.build.flags.optimize=-Og
+genericGD32F103C.menu.opt.ogstd.build.flags.ldspecs=
+genericGD32F103C.menu.opt.oglto=Debug with LTO
+genericGD32F103C.menu.opt.oglto.build.flags.optimize=-Og -flto
+genericGD32F103C.menu.opt.oglto.build.flags.ldspecs=-flto
+genericGD32F103C.menu.opt.osstd=Smallest Code
+genericGD32F103C.menu.opt.osstd.build.flags.optimize=-Os
+genericGD32F103C.menu.opt.osstd.build.flags.ldspecs=
+genericGD32F103C.menu.opt.oslto=Smallest Code with LTO
+genericGD32F103C.menu.opt.oslto.build.flags.optimize=-Os -flto
+genericGD32F103C.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ########################### STM32VLD to FLASH ###########################
 
 STM32VLD.name=STM32VLD to FLASH
@@ -604,5 +988,36 @@ STM32VLD.menu.upload_method.STLinkMethod.upload.protocol=STLink
 STM32VLD.menu.upload_method.STLinkMethod.upload.tool=stlink_upload
 STM32VLD.menu.upload_method.STLinkMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG  
 
+#-- Optimizations
+STM32VLD.menu.opt.o2std=Faster
+STM32VLD.menu.opt.o2std.build.flags.optimize=-O2
+STM32VLD.menu.opt.o2std.build.flags.ldspecs=
+STM32VLD.menu.opt.o2lto=Faster with LTO
+STM32VLD.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+STM32VLD.menu.opt.o2lto.build.flags.ldspecs=-flto
+STM32VLD.menu.opt.o1std=Fast
+STM32VLD.menu.opt.o1std.build.flags.optimize=-O1
+STM32VLD.menu.opt.o1std.build.flags.ldspecs=
+STM32VLD.menu.opt.o1lto=Fast with LTO
+STM32VLD.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+STM32VLD.menu.opt.o1lto.build.flags.ldspecs=-flto
+STM32VLD.menu.opt.o3std=Fastest
+STM32VLD.menu.opt.o3std.build.flags.optimize=-O3
+STM32VLD.menu.opt.o3std.build.flags.ldspecs=
+STM32VLD.menu.opt.o3lto=Fastest with LTO
+STM32VLD.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+STM32VLD.menu.opt.o3lto.build.flags.ldspecs=-flto
+STM32VLD.menu.opt.ogstd=Debug
+STM32VLD.menu.opt.ogstd.build.flags.optimize=-Og
+STM32VLD.menu.opt.ogstd.build.flags.ldspecs=
+STM32VLD.menu.opt.oglto=Debug with LTO
+STM32VLD.menu.opt.oglto.build.flags.optimize=-Og -flto
+STM32VLD.menu.opt.oglto.build.flags.ldspecs=-flto
+STM32VLD.menu.opt.osstd=Smallest Code
+STM32VLD.menu.opt.osstd.build.flags.optimize=-Os
+STM32VLD.menu.opt.osstd.build.flags.ldspecs=
+STM32VLD.menu.opt.oslto=Smallest Code with LTO
+STM32VLD.menu.opt.oslto.build.flags.optimize=-Os -flto
+STM32VLD.menu.opt.oslto.build.flags.ldspecs=-flto
 
 ################################################################################

--- a/STM32F1/platform.txt
+++ b/STM32F1/platform.txt
@@ -16,20 +16,20 @@ compiler.warning_flags.all=-Wall -Wextra -DDEBUG_LEVEL=DEBUG_ALL
 # ----------------------
 compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
+compiler.c.flags=-c -g {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
 compiler.c.elf.cmd=arm-none-eabi-g++
-compiler.c.elf.flags=-Os -Wl,--gc-sections
+compiler.c.elf.flags={build.flags.optimize} -Wl,--gc-sections {build.flags.ldspecs}
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
+compiler.cpp.flags=-c -g {build.flags.optimize} {compiler.warning_flags} -std=gnu++11 -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
 compiler.elf2hex.flags=-O binary
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
-compiler.ldflags=
+compiler.ldflags={build.flags.ldspecs}
 compiler.size.cmd=arm-none-eabi-size
 compiler.define=-DARDUINO=                            
 

--- a/STM32F3/boards.txt
+++ b/STM32F3/boards.txt
@@ -28,5 +28,37 @@ discovery_f3.build.error_led_port=GPIOE
 discovery_f3.build.error_led_pin=8
 discovery_f3.build.board=STM32F3Discovery
 
+#-- Optimizations
+discovery_f3.menu.opt.o2std=Faster
+discovery_f3.menu.opt.o2std.build.flags.optimize=-O2
+discovery_f3.menu.opt.o2std.build.flags.ldspecs=
+discovery_f3.menu.opt.o2lto=Faster with LTO
+discovery_f3.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+discovery_f3.menu.opt.o2lto.build.flags.ldspecs=-flto
+discovery_f3.menu.opt.o1std=Fast
+discovery_f3.menu.opt.o1std.build.flags.optimize=-O1
+discovery_f3.menu.opt.o1std.build.flags.ldspecs=
+discovery_f3.menu.opt.o1lto=Fast with LTO
+discovery_f3.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+discovery_f3.menu.opt.o1lto.build.flags.ldspecs=-flto
+discovery_f3.menu.opt.o3std=Fastest
+discovery_f3.menu.opt.o3std.build.flags.optimize=-O3
+discovery_f3.menu.opt.o3std.build.flags.ldspecs=
+discovery_f3.menu.opt.o3lto=Fastest with LTO
+discovery_f3.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+discovery_f3.menu.opt.o3lto.build.flags.ldspecs=-flto
+discovery_f3.menu.opt.ogstd=Debug
+discovery_f3.menu.opt.ogstd.build.flags.optimize=-Og
+discovery_f3.menu.opt.ogstd.build.flags.ldspecs=
+discovery_f3.menu.opt.oglto=Debug with LTO
+discovery_f3.menu.opt.oglto.build.flags.optimize=-Og -flto
+discovery_f3.menu.opt.oglto.build.flags.ldspecs=-flto
+discovery_f3.menu.opt.osstd=Smallest Code
+discovery_f3.menu.opt.osstd.build.flags.optimize=-Os
+discovery_f3.menu.opt.osstd.build.flags.ldspecs=
+discovery_f3.menu.opt.oslto=Smallest Code with LTO
+discovery_f3.menu.opt.oslto.build.flags.optimize=-Os -flto
+discovery_f3.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ##############################################################
 

--- a/STM32F3/boards.txt
+++ b/STM32F3/boards.txt
@@ -1,5 +1,7 @@
 # 
 
+menu.opt=Optimize
+
 ##############################################################
 discovery_f3.name=STM32F3Discovery
 

--- a/STM32F3/platform.txt
+++ b/STM32F3/platform.txt
@@ -12,20 +12,20 @@ version=0.1.0
 
 compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -Os -w -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin}
+compiler.c.flags=-c -g {build.flags.optimize} -w -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin}
 compiler.c.elf.cmd=arm-none-eabi-g++
-compiler.c.elf.flags=-Os -Wl,--gc-sections
+compiler.c.elf.flags={build.flags.optimize} -Wl,--gc-sections {build.flags.ldspecs}
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -Os -w -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
+compiler.cpp.flags=-c -g {build.flags.optimize} -w -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
 compiler.elf2hex.flags=-O binary
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
-compiler.ldflags=
+compiler.ldflags={build.flags.ldspecs}
 compiler.size.cmd=arm-none-eabi-size
 compiler.define=-DARDUINO=                            
 

--- a/STM32F4/boards.txt
+++ b/STM32F4/boards.txt
@@ -1,6 +1,7 @@
 # 
 
 menu.usb_cfg=USB configuration
+menu.opt=Optimize
 
 ##############################################################
 discovery_f407.name=STM32 Discovery F407

--- a/STM32F4/boards.txt
+++ b/STM32F4/boards.txt
@@ -36,6 +36,39 @@ discovery_f407.menu.usb_cfg.usb_serial=USB serial (CDC)
 discovery_f407.menu.usb_cfg.usb_serial.build.cpu_flags=-DSERIAL_USB
 discovery_f407.menu.usb_cfg.usb_msc=USB Mass Storage (MSC)
 discovery_f407.menu.usb_cfg.usb_msc.build.cpu_flags=-DUSB_MSC
+
+#-- Optimizations
+discovery_f407.menu.opt.o2std=Faster
+discovery_f407.menu.opt.o2std.build.flags.optimize=-O2
+discovery_f407.menu.opt.o2std.build.flags.ldspecs=
+discovery_f407.menu.opt.o2lto=Faster with LTO
+discovery_f407.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+discovery_f407.menu.opt.o2lto.build.flags.ldspecs=-flto
+discovery_f407.menu.opt.o1std=Fast
+discovery_f407.menu.opt.o1std.build.flags.optimize=-O1
+discovery_f407.menu.opt.o1std.build.flags.ldspecs=
+discovery_f407.menu.opt.o1lto=Fast with LTO
+discovery_f407.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+discovery_f407.menu.opt.o1lto.build.flags.ldspecs=-flto
+discovery_f407.menu.opt.o3std=Fastest
+discovery_f407.menu.opt.o3std.build.flags.optimize=-O3
+discovery_f407.menu.opt.o3std.build.flags.ldspecs=
+discovery_f407.menu.opt.o3lto=Fastest with LTO
+discovery_f407.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+discovery_f407.menu.opt.o3lto.build.flags.ldspecs=-flto
+discovery_f407.menu.opt.ogstd=Debug
+discovery_f407.menu.opt.ogstd.build.flags.optimize=-Og
+discovery_f407.menu.opt.ogstd.build.flags.ldspecs=
+discovery_f407.menu.opt.oglto=Debug with LTO
+discovery_f407.menu.opt.oglto.build.flags.optimize=-Og -flto
+discovery_f407.menu.opt.oglto.build.flags.ldspecs=-flto
+discovery_f407.menu.opt.osstd=Smallest Code
+discovery_f407.menu.opt.osstd.build.flags.optimize=-Os
+discovery_f407.menu.opt.osstd.build.flags.ldspecs=
+discovery_f407.menu.opt.oslto=Smallest Code with LTO
+discovery_f407.menu.opt.oslto.build.flags.optimize=-Os -flto
+discovery_f407.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ##############################################################
 generic_f407v.name=Generic STM32F407V series
 
@@ -72,6 +105,38 @@ generic_f407v.menu.usb_cfg.usb_serial.build.cpu_flags=-DSERIAL_USB
 generic_f407v.menu.usb_cfg.usb_msc=USB Mass Storage (MSC)
 generic_f407v.menu.usb_cfg.usb_msc.build.cpu_flags=-DUSB_MSC
 
+#-- Optimizations
+generic_f407v.menu.opt.o2std=Faster
+generic_f407v.menu.opt.o2std.build.flags.optimize=-O2
+generic_f407v.menu.opt.o2std.build.flags.ldspecs=
+generic_f407v.menu.opt.o2lto=Faster with LTO
+generic_f407v.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+generic_f407v.menu.opt.o2lto.build.flags.ldspecs=-flto
+generic_f407v.menu.opt.o1std=Fast
+generic_f407v.menu.opt.o1std.build.flags.optimize=-O1
+generic_f407v.menu.opt.o1std.build.flags.ldspecs=
+generic_f407v.menu.opt.o1lto=Fast with LTO
+generic_f407v.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+generic_f407v.menu.opt.o1lto.build.flags.ldspecs=-flto
+generic_f407v.menu.opt.o3std=Fastest
+generic_f407v.menu.opt.o3std.build.flags.optimize=-O3
+generic_f407v.menu.opt.o3std.build.flags.ldspecs=
+generic_f407v.menu.opt.o3lto=Fastest with LTO
+generic_f407v.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+generic_f407v.menu.opt.o3lto.build.flags.ldspecs=-flto
+generic_f407v.menu.opt.ogstd=Debug
+generic_f407v.menu.opt.ogstd.build.flags.optimize=-Og
+generic_f407v.menu.opt.ogstd.build.flags.ldspecs=
+generic_f407v.menu.opt.oglto=Debug with LTO
+generic_f407v.menu.opt.oglto.build.flags.optimize=-Og -flto
+generic_f407v.menu.opt.oglto.build.flags.ldspecs=-flto
+generic_f407v.menu.opt.osstd=Smallest Code
+generic_f407v.menu.opt.osstd.build.flags.optimize=-Os
+generic_f407v.menu.opt.osstd.build.flags.ldspecs=
+generic_f407v.menu.opt.oslto=Smallest Code with LTO
+generic_f407v.menu.opt.oslto.build.flags.optimize=-Os -flto
+generic_f407v.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ##############################################################
 stm32f4stamp.name=STM32F4Stamp F405
 
@@ -107,6 +172,39 @@ stm32f4stamp.menu.usb_cfg.usb_serial=USB serial (CDC)
 stm32f4stamp.menu.usb_cfg.usb_serial.build.cpu_flags=-DSERIAL_USB
 stm32f4stamp.menu.usb_cfg.usb_msc=USB Mass Storage (MSC)
 stm32f4stamp.menu.usb_cfg.usb_msc.build.cpu_flags=-DUSB_MSC
+
+#-- Optimizations
+stm32f4stamp.menu.opt.o2std=Faster
+stm32f4stamp.menu.opt.o2std.build.flags.optimize=-O2
+stm32f4stamp.menu.opt.o2std.build.flags.ldspecs=
+stm32f4stamp.menu.opt.o2lto=Faster with LTO
+stm32f4stamp.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+stm32f4stamp.menu.opt.o2lto.build.flags.ldspecs=-flto
+stm32f4stamp.menu.opt.o1std=Fast
+stm32f4stamp.menu.opt.o1std.build.flags.optimize=-O1
+stm32f4stamp.menu.opt.o1std.build.flags.ldspecs=
+stm32f4stamp.menu.opt.o1lto=Fast with LTO
+stm32f4stamp.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+stm32f4stamp.menu.opt.o1lto.build.flags.ldspecs=-flto
+stm32f4stamp.menu.opt.o3std=Fastest
+stm32f4stamp.menu.opt.o3std.build.flags.optimize=-O3
+stm32f4stamp.menu.opt.o3std.build.flags.ldspecs=
+stm32f4stamp.menu.opt.o3lto=Fastest with LTO
+stm32f4stamp.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+stm32f4stamp.menu.opt.o3lto.build.flags.ldspecs=-flto
+stm32f4stamp.menu.opt.ogstd=Debug
+stm32f4stamp.menu.opt.ogstd.build.flags.optimize=-Og
+stm32f4stamp.menu.opt.ogstd.build.flags.ldspecs=
+stm32f4stamp.menu.opt.oglto=Debug with LTO
+stm32f4stamp.menu.opt.oglto.build.flags.optimize=-Og -flto
+stm32f4stamp.menu.opt.oglto.build.flags.ldspecs=-flto
+stm32f4stamp.menu.opt.osstd=Smallest Code
+stm32f4stamp.menu.opt.osstd.build.flags.optimize=-Os
+stm32f4stamp.menu.opt.osstd.build.flags.ldspecs=
+stm32f4stamp.menu.opt.oslto=Smallest Code with LTO
+stm32f4stamp.menu.opt.oslto.build.flags.optimize=-Os -flto
+stm32f4stamp.menu.opt.oslto.build.flags.ldspecs=-flto
+
 ##############################################################
 netduino2plus.name=Netduino2 F405
 
@@ -142,5 +240,37 @@ netduino2plus.menu.usb_cfg.usb_serial=USB serial (CDC)
 netduino2plus.menu.usb_cfg.usb_serial.build.cpu_flags=-DSERIAL_USB
 netduino2plus.menu.usb_cfg.usb_msc=USB Mass Storage (MSC)
 netduino2plus.menu.usb_cfg.usb_msc.build.cpu_flags=-DUSB_MSC
-##############################################################
 
+#-- Optimizations
+netduino2plus.menu.opt.o2std=Faster
+netduino2plus.menu.opt.o2std.build.flags.optimize=-O2
+netduino2plus.menu.opt.o2std.build.flags.ldspecs=
+netduino2plus.menu.opt.o2lto=Faster with LTO
+netduino2plus.menu.opt.o2lto.build.flags.optimize=-O2 -flto
+netduino2plus.menu.opt.o2lto.build.flags.ldspecs=-flto
+netduino2plus.menu.opt.o1std=Fast
+netduino2plus.menu.opt.o1std.build.flags.optimize=-O1
+netduino2plus.menu.opt.o1std.build.flags.ldspecs=
+netduino2plus.menu.opt.o1lto=Fast with LTO
+netduino2plus.menu.opt.o1lto.build.flags.optimize=-O1 -flto
+netduino2plus.menu.opt.o1lto.build.flags.ldspecs=-flto
+netduino2plus.menu.opt.o3std=Fastest
+netduino2plus.menu.opt.o3std.build.flags.optimize=-O3
+netduino2plus.menu.opt.o3std.build.flags.ldspecs=
+netduino2plus.menu.opt.o3lto=Fastest with LTO
+netduino2plus.menu.opt.o3lto.build.flags.optimize=-O3 -flto
+netduino2plus.menu.opt.o3lto.build.flags.ldspecs=-flto
+netduino2plus.menu.opt.ogstd=Debug
+netduino2plus.menu.opt.ogstd.build.flags.optimize=-Og
+netduino2plus.menu.opt.ogstd.build.flags.ldspecs=
+netduino2plus.menu.opt.oglto=Debug with LTO
+netduino2plus.menu.opt.oglto.build.flags.optimize=-Og -flto
+netduino2plus.menu.opt.oglto.build.flags.ldspecs=-flto
+netduino2plus.menu.opt.osstd=Smallest Code
+netduino2plus.menu.opt.osstd.build.flags.optimize=-Os
+netduino2plus.menu.opt.osstd.build.flags.ldspecs=
+netduino2plus.menu.opt.oslto=Smallest Code with LTO
+netduino2plus.menu.opt.oslto.build.flags.optimize=-Os -flto
+netduino2plus.menu.opt.oslto.build.flags.ldspecs=-flto
+
+##############################################################

--- a/STM32F4/platform.txt
+++ b/STM32F4/platform.txt
@@ -10,20 +10,20 @@ version=0.1.0
 # ----------------------
 compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -Os -Wall -MMD -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin}
+compiler.c.flags=-c -g {build.flags.optimize} -Wall -MMD -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin}
 compiler.c.elf.cmd=arm-none-eabi-g++
-compiler.c.elf.flags=-Os -Wl,--gc-sections
+compiler.c.elf.flags={build.flags.optimize} -Wl,--gc-sections {build.flags.ldspecs}
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -Os -Wall -MMD -std=gnu++11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin}
+compiler.cpp.flags=-c -g {build.flags.optimize} -Wall -MMD -std=gnu++11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin}
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
 compiler.elf2hex.flags=-O binary
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
-compiler.ldflags=
+compiler.ldflags={build.flags.ldspecs}
 compiler.size.cmd=arm-none-eabi-size
 compiler.define=-DARDUINO=                            
 


### PR DESCRIPTION
Added compiler optimizations menu options just like in Teensy IDE. In short: users are able to switch now much more easily between various compiler options by using the Arduino IDE menu.

Available options are(F1 maple mini board for example):
#-- Optimizations
mapleMini.menu.opt.o2std=Faster
mapleMini.menu.opt.o2std.build.flags.optimize=-O2
mapleMini.menu.opt.o2std.build.flags.ldspecs=
mapleMini.menu.opt.o2lto=Faster with LTO
mapleMini.menu.opt.o2lto.build.flags.optimize=-O2 -flto
mapleMini.menu.opt.o2lto.build.flags.ldspecs=-flto
mapleMini.menu.opt.o1std=Fast
mapleMini.menu.opt.o1std.build.flags.optimize=-O1
mapleMini.menu.opt.o1std.build.flags.ldspecs=
mapleMini.menu.opt.o1lto=Fast with LTO
mapleMini.menu.opt.o1lto.build.flags.optimize=-O1 -flto
mapleMini.menu.opt.o1lto.build.flags.ldspecs=-flto
mapleMini.menu.opt.o3std=Fastest
mapleMini.menu.opt.o3std.build.flags.optimize=-O3
mapleMini.menu.opt.o3std.build.flags.ldspecs=
mapleMini.menu.opt.o3lto=Fastest with LTO
mapleMini.menu.opt.o3lto.build.flags.optimize=-O3 -flto
mapleMini.menu.opt.o3lto.build.flags.ldspecs=-flto
mapleMini.menu.opt.ogstd=Debug
mapleMini.menu.opt.ogstd.build.flags.optimize=-Og
mapleMini.menu.opt.ogstd.build.flags.ldspecs=
mapleMini.menu.opt.oglto=Debug with LTO
mapleMini.menu.opt.oglto.build.flags.optimize=-Og -flto
mapleMini.menu.opt.oglto.build.flags.ldspecs=-flto
mapleMini.menu.opt.osstd=Smallest Code
mapleMini.menu.opt.osstd.build.flags.optimize=-Os
mapleMini.menu.opt.osstd.build.flags.ldspecs=
mapleMini.menu.opt.oslto=Smallest Code with LTO
mapleMini.menu.opt.oslto.build.flags.optimize=-Os -flto
mapleMini.menu.opt.oslto.build.flags.ldspecs=-flto

The rest of the boards:F3/F4 have the same options added. I don't take any credits for this - the idea was borrowed from Teensy Arduino IDE implementation so all the credits go to them.

I also picked the platform.txt changes for LTO from @grafalex82(all credits go to him for providing those) and incorporated here in the menu options and in each platform.txt file as required. In the future will be easier I guess to modify those in boards.txt only rather than platform.txt.

I  tested this by just compiling/recompiling the some sketches for some F1/F3/F4 boards and it worked - I also checked that the compiler flags were passed in correctly by following the console output from the Arduino IDE. The differences are easily seen in the final binary size. I don't have time to test on real boards so if anyone can do that then please do. Thanks.