### PR TITLE
F103C8 128kB flash upload

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -178,12 +178,19 @@ genericSTM32F103C.menu.device_variant.STM32F103C8.build.ldscript=ld/jtag_c8.ld
 genericSTM32F103C.menu.device_variant.STM32F103C8.upload.maximum_size=65536
 genericSTM32F103C.menu.device_variant.STM32F103C8.upload.maximum_data_size=20480
 
+## STM32F103C8 -------------------------
+genericSTM32F103C.menu.device_variant.STM32F103C8x=STM32F103C8 (20k RAM. 128k Flash)
+genericSTM32F103C.menu.device_variant.STM32F103C8x.build.cpu_flags=-DMCU_STM32F103C8
+genericSTM32F103C.menu.device_variant.STM32F103C8x.build.ldscript=ld/jtag.ld
+genericSTM32F103C.menu.device_variant.STM32F103C8x.upload.maximum_size=131072
+genericSTM32F103C.menu.device_variant.STM32F103C8x.upload.maximum_data_size=20480
+
 ## STM32F103CB -------------------------
 genericSTM32F103C.menu.device_variant.STM32F103CB=STM32F103CB (20k RAM. 128k Flash)
 genericSTM32F103C.menu.device_variant.STM32F103CB.build.cpu_flags=-DMCU_STM32F103CB
 genericSTM32F103C.menu.device_variant.STM32F103CB.build.ldscript=ld/jtag.ld
 genericSTM32F103C.menu.device_variant.STM32F103CB.upload.maximum_size=131072
-genericSTM32F103C.menu.device_variant.STM32F103C8.upload.maximum_data_size=20480
+genericSTM32F103C.menu.device_variant.STM32F103CB.upload.maximum_data_size=20480
 
 #---------------------------- UPLOAD METHODS ---------------------------
 

--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -179,7 +179,7 @@ genericSTM32F103C.menu.device_variant.STM32F103C8.upload.maximum_size=65536
 genericSTM32F103C.menu.device_variant.STM32F103C8.upload.maximum_data_size=20480
 
 ## STM32F103C8 -------------------------
-genericSTM32F103C.menu.device_variant.STM32F103C8x=STM32F103C8 (20k RAM. 128k Flash)
+genericSTM32F103C.menu.device_variant.STM32F103C8x=STM32F103C8 Experimental (20k RAM. 128k Flash)
 genericSTM32F103C.menu.device_variant.STM32F103C8x.build.cpu_flags=-DMCU_STM32F103C8
 genericSTM32F103C.menu.device_variant.STM32F103C8x.build.ldscript=ld/jtag.ld
 genericSTM32F103C.menu.device_variant.STM32F103C8x.upload.maximum_size=131072


### PR DESCRIPTION
Added F103C8 128kB flash upload, functionality largely accepted as working and present on the wiki.