### PR TITLE
linux fix for gd32 variant in boards.txt

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -931,7 +931,7 @@ hytiny-stm32f103t.menu.opt.ogstd.build.flags.ldspecs=
 ###################### Generic GD32F103C  ########################################
 
 genericGD32F103C.name=Generic GD32F103C series
-genericGD32F103C.build.variant=generic_GD32f103c
+genericGD32F103C.build.variant=generic_gd32f103c
 genericGD32F103C.build.vect=VECT_TAB_ADDR=0x8000000
 genericGD32F103C.build.core=maple
 genericGD32F103C.build.board=GENERIC_GD32F103C


### PR DESCRIPTION
Linux is case sensitive so it matters when it comes to files/folder names. This fixes GD32F103xx variants in boards.txt to pick the right folder at compile time.

Otherwise this happens:
```
...
#include <board/board.h>
                         ^
compilation terminated.
exit status 1
Error compiling for board Generic GD32F103C series.
```