### PR TITLE
Correcting FreeRTOS900 examples to include right version

### DIFF
--- a/STM32F1/libraries/FreeRTOS900/examples/rtos_blink/rtos_blink.ino
+++ b/STM32F1/libraries/FreeRTOS900/examples/rtos_blink/rtos_blink.ino
@@ -1,6 +1,6 @@
 //#include <wirish/wirish.h>
 //#include "libraries/FreeRTOS/MapleFreeRTOS.h"
-#include <MapleFreeRTOS821.h>
+#include <MapleFreeRTOS900.h>
 
 static void vLEDFlashTask(void *pvParameters) {
     for (;;) {

--- a/STM32F1/libraries/FreeRTOS900/examples/rtos_display_blink/rtos_display_blink.ino
+++ b/STM32F1/libraries/FreeRTOS900/examples/rtos_display_blink/rtos_display_blink.ino
@@ -1,5 +1,5 @@
 #define USE_SEMAPHORE_DMA1
-#include <MapleFreeRTOS821.h>
+#include <MapleFreeRTOS900.h>
 #include <SPI.h>
 #include <Adafruit_GFX.h>
 #include <TFT_ILI9163C.h>


### PR DESCRIPTION
The examples had not been edited to use the FreeRTOS 9.0 version, so correcting that now.