### PR TITLE
add JLink upload support for OSX

### DIFF
--- a/tools/macosx/jlink_upload
+++ b/tools/macosx/jlink_upload
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo erase > "$1".jlink
+echo loadbin "$1" , 0x8000000 >> "$1".jlink
+echo r >> "$1".jlink
+echo q >> "$1".jlink
+
+/Applications/SEGGER/JLink/JLinkExe -device STM32F103C8 -if SWD -speed auto -CommanderScript "$1".jlink
+


### PR DESCRIPTION
This is tested using a chinese JLink clone with Arduino 1.8.3 and a unmodified Blue Pill board
Requires the JLink binaries pre-installed from https://www.segger.com/downloads/jlink/

This is identical to the linux/jlink_upload except for the path to the binary