### PR TITLE
Correct issue with I2C port speed not changing after begin()

### DIFF
--- a/STM32F1/libraries/Wire/Wire.cpp
+++ b/STM32F1/libraries/Wire/Wire.cpp
@@ -97,8 +97,10 @@ void HardWire::setClock(uint32_t frequencyHz)
 			dev_flags &= ~I2C_FAST_MODE;// clear FAST_MODE bit
 			break;
 	}
-	i2c_disable(sel_hard);
-	i2c_master_enable(sel_hard, dev_flags);
+	if (sel_hard->regs->CR1 & I2C_CR1_PE){
+	    i2c_disable(sel_hard);
+	    i2c_master_enable(sel_hard, dev_flags);
+	}
 }
 
 HardWire Wire(1);

--- a/STM32F1/libraries/Wire/Wire.cpp
+++ b/STM32F1/libraries/Wire/Wire.cpp
@@ -97,7 +97,8 @@ void HardWire::setClock(uint32_t frequencyHz)
 			dev_flags &= ~I2C_FAST_MODE;// clear FAST_MODE bit
 			break;
 	}
-	
+	i2c_disable(sel_hard);
+	i2c_master_enable(sel_hard, dev_flags);
 }
 
 HardWire Wire(1);


### PR DESCRIPTION
The current implementation will not change speed if Wire.setClock is called after begin() since the flags are only applied when the port is enabled from being disabled.
Corrected that by adding 2 lines to disable the port, and then enable it again with the new settings.
Tested and confirmed the new speed is applied.