### PR TITLE
Leadingzero support for STM32F1 print and println

### DIFF
--- a/STM32F1/cores/maple/Print.cpp
+++ b/STM32F1/cores/maple/Print.cpp
@@ -65,8 +65,8 @@ size_t Print::write(const void *buffer, uint32 size) {
 	return n;
 }
 
-size_t Print::print(uint8 b, int base) {
-    return print((uint64)b, base);
+size_t Print::print(uint8 b, int base, int arg) {
+    return print((uint64)b, base, arg);
 }
 
 size_t Print::print(const String &s)
@@ -82,23 +82,23 @@ size_t Print::print(const char str[]) {
     return write(str);
 }
 
-size_t Print::print(int n, int base) {
-    return print((long long)n, base);
+size_t Print::print(int n, int base, int arg) {
+    return print((long long)n, base, arg);
 }
 
-size_t Print::print(unsigned int n, int base) {
-    return print((unsigned long long)n, base);
+size_t Print::print(unsigned int n, int base, int arg) {
+    return print((unsigned long long)n, base, arg);
 }
 
-size_t Print::print(long n, int base) {
-    return print((long long)n, base);
+size_t Print::print(long n, int base, int arg) {
+    return print((long long)n, base, arg);
 }
 
-size_t Print::print(unsigned long n, int base) {
-    return print((unsigned long long)n, base);
+size_t Print::print(unsigned long n, int base, int arg) {
+    return print((unsigned long long)n, base, arg);
 }
 
-size_t Print::print(long long n, int base) {
+size_t Print::print(long long n, int base, int arg) {
     if (base == BYTE) 
 	{
         return write((uint8)n);
@@ -107,15 +107,15 @@ size_t Print::print(long long n, int base) {
         print('-');
         n = -n;
     }
-    return printNumber(n, base);
+    return printNumber(n, base, arg);
 }
 
-size_t Print::print(unsigned long long n, int base) {
+size_t Print::print(unsigned long long n, int base, int arg) {
 size_t c=0;
     if (base == BYTE) {
         c= write((uint8)n);
     } else {
-        c= printNumber(n, base);
+        c= printNumber(n, base, arg);
     }
 	return c;
 }
@@ -160,44 +160,44 @@ size_t Print::println(const char c[]) {
 	return n;
 }
 
-size_t Print::println(uint8 b, int base) {
+size_t Print::println(uint8 b, int base, int arg) {
     size_t n = print(b, base);
 	n += println();
 	return n;
 }
 
-size_t Print::println(int n, int base) {
-    size_t s = print(n, base);
+size_t Print::println(int n, int base, int arg) {
+    size_t s = print(n, base, arg);
     s += println();
 	return s;
 }
 
-size_t Print::println(unsigned int n, int base) {
-    size_t s = print(n, base);
+size_t Print::println(unsigned int n, int base, int arg) {
+    size_t s = print(n, base, arg);
     s += println();
 	return s;
 }
 
-size_t Print::println(long n, int base) {
-    size_t s = print((long long)n, base);
+size_t Print::println(long n, int base, int arg) {
+    size_t s = print((long long)n, base, arg);
     s += println();
 	return s;
 }
 
-size_t Print::println(unsigned long n, int base) {
-    size_t s = print((unsigned long long)n, base);
+size_t Print::println(unsigned long n, int base, int arg) {
+    size_t s = print((unsigned long long)n, base, arg);
     s += println();
 	return s;
 }
 
-size_t Print::println(long long n, int base) {
-    size_t s = print(n, base);
+size_t Print::println(long long n, int base, int arg) {
+    size_t s = print(n, base, arg);
     s += println();
 	return s;
 }
 
-size_t Print::println(unsigned long long n, int base) {
-    size_t s = print(n, base);
+size_t Print::println(unsigned long long n, int base, int arg) {
+    size_t s = print(n, base, arg);
     s += println();
 	return s;
 }
@@ -245,13 +245,27 @@ FILE *__restrict __stream;
  * Private methods
  */
 
-size_t Print::printNumber(unsigned long long n, uint8 base) {
+size_t Print::printNumber(unsigned long long n, uint8 base, uint8 arg) {
     unsigned char buf[CHAR_BIT * sizeof(long long)];
     unsigned long i = 0;
+	if( (base != HEX) || ( n > 16 ))arg = PRINT_NOARG;
 	size_t s=0;
+	
+	if(arg==1)s += print('0');
+	
     if (n == 0) {
-        print('0');
-        return 1;
+        
+        if(arg==1)
+		{
+			s += print('0');
+			return s;
+		}
+		else 
+		{
+			print('0');
+			return 1;
+		}
+			
     }
 
     while (n > 0) {
@@ -264,6 +278,7 @@ size_t Print::printNumber(unsigned long long n, uint8 base) {
                      '0' + buf[i - 1] :
                      'A' + buf[i - 1] - 10));
     }
+	
 	return s;
 }
 
@@ -329,4 +344,3 @@ size_t s=0;
     }
 	return s;
 }
-

--- a/STM32F1/cores/maple/Print.h
+++ b/STM32F1/cores/maple/Print.h
@@ -35,6 +35,11 @@ enum {
     HEX  = 16
 };
 
+enum {
+	PRINT_NOARG,
+	PRINT_LEADINGZERO
+};
+
 class Print {
 public:
     virtual size_t write(uint8 ch) = 0;
@@ -44,13 +49,13 @@ public:
 	size_t print(const String &);
     size_t print(char);
     size_t print(const char[]);
-    size_t print(uint8, int=DEC);
-    size_t print(int, int=DEC);
-    size_t print(unsigned int, int=DEC);
-    size_t print(long, int=DEC);
-    size_t print(unsigned long, int=DEC);
-    size_t print(long long, int=DEC);
-    size_t print(unsigned long long, int=DEC);
+    size_t print(uint8, int=DEC, int=PRINT_NOARG);
+    size_t print(int, int=DEC, int=PRINT_NOARG);
+    size_t print(unsigned int, int=DEC, int=PRINT_NOARG);
+    size_t print(long, int=DEC, int=PRINT_NOARG);
+    size_t print(unsigned long, int=DEC, int=PRINT_NOARG);
+    size_t print(long long, int=DEC, int=PRINT_NOARG);
+    size_t print(unsigned long long, int=DEC, int=PRINT_NOARG);
     size_t print(double, int=2);
     size_t print(const __FlashStringHelper *);
     size_t print(const Printable&);
@@ -58,13 +63,13 @@ public:
 	size_t println(const String &s);
 	size_t println(char);
 	size_t println(const char[]);
-    size_t println(uint8, int=DEC);
-    size_t println(int, int=DEC);
-    size_t println(unsigned int, int=DEC);
-    size_t println(long, int=DEC);
-    size_t println(unsigned long, int=DEC);
-    size_t println(long long, int=DEC);
-    size_t println(unsigned long long, int=DEC);
+    size_t println(uint8, int=DEC, int=PRINT_NOARG);
+    size_t println(int, int=DEC, int=PRINT_NOARG);
+    size_t println(unsigned int, int=DEC, int=PRINT_NOARG);
+    size_t println(long, int=DEC, int=PRINT_NOARG);
+    size_t println(unsigned long, int=DEC, int=PRINT_NOARG);
+    size_t println(long long, int=DEC, int=PRINT_NOARG);
+    size_t println(unsigned long long, int=DEC, int=PRINT_NOARG);
     size_t println(double, int=2);
     size_t println(const __FlashStringHelper *);
     size_t println(const Printable&);
@@ -82,7 +87,7 @@ public:
 
 private:
 	int write_error;
-    size_t printNumber(unsigned long long, uint8);
+    size_t printNumber(unsigned long long, uint8, uint8);
     size_t printFloat(double, uint8);
 };
 


### PR DESCRIPTION
Added an extra optional argument for print and println
Default value = PRINT_NOARG
When the value is PRINT_LEADINGZERO, all HEX values will have a leading zero :+1: 