### PR TITLE
SPI add const qualifier

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -350,10 +350,10 @@ void SPIClass::write(uint16 data, uint32 n)
     while ( (regs->SR & SPI_SR_BSY) != 0); // wait until BSY=0 before returning 
 }
 
-void SPIClass::write(void *data, uint32 length)
+void SPIClass::write(const void *data, uint32 length)
 {
     spi_dev * spi_d = _currentSetting->spi_d;
-    spi_tx(spi_d, (void*)data, length); // data can be array of bytes or words
+    spi_tx(spi_d, data, length); // data can be array of bytes or words
     while (spi_is_tx_empty(spi_d) == 0); // "5. Wait until TXE=1 ..."
     while (spi_is_busy(spi_d) != 0); // "... and then wait until BSY=0 before disabling the SPI."
 }
@@ -391,7 +391,7 @@ uint16_t SPIClass::transfer16(uint16_t data) const
 *	On exit TX buffer is not modified, and RX buffer cotains the received data.
 *	Still in progress.
 */
-void SPIClass::dmaTransferSet(void *transmitBuf, void *receiveBuf) {
+void SPIClass::dmaTransferSet(const void *transmitBuf, void *receiveBuf) {
     dma_init(_currentSetting->spiDmaDev);
     //spi_rx_dma_enable(_currentSetting->spi_d);
     //spi_tx_dma_enable(_currentSetting->spi_d);
@@ -401,11 +401,11 @@ void SPIClass::dmaTransferSet(void *transmitBuf, void *receiveBuf) {
     if (!transmitBuf) {
     transmitBuf = &ff;
     dma_setup_transfer(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &_currentSetting->spi_d->regs->DR, dma_bit_size,
-                       transmitBuf, dma_bit_size, (DMA_FROM_MEM));// Transmit FF repeatedly
+                       (volatile void*)transmitBuf, dma_bit_size, (DMA_FROM_MEM));// Transmit FF repeatedly
     }
     else {
     dma_setup_transfer(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &_currentSetting->spi_d->regs->DR, dma_bit_size,
-                       transmitBuf, dma_bit_size, (DMA_MINC_MODE |  DMA_FROM_MEM ));// Transmit buffer DMA
+                       (volatile void*)transmitBuf, dma_bit_size, (DMA_MINC_MODE |  DMA_FROM_MEM ));// Transmit buffer DMA
     }
     dma_set_priority(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, DMA_PRIORITY_LOW);
     dma_set_priority(_currentSetting->spiDmaDev, _currentSetting->spiRxDmaChannel, DMA_PRIORITY_VERY_HIGH);
@@ -451,7 +451,7 @@ uint8 SPIClass::dmaTransferRepeat(uint16 length) {
 *	Still in progress.
 */
 
-uint8 SPIClass::dmaTransfer(void *transmitBuf, void *receiveBuf, uint16 length) {
+uint8 SPIClass::dmaTransfer(const void *transmitBuf, void *receiveBuf, uint16 length) {
     dmaTransferSet(transmitBuf, receiveBuf);
     return dmaTransferRepeat(length);
 }
@@ -463,12 +463,12 @@ uint8 SPIClass::dmaTransfer(void *transmitBuf, void *receiveBuf, uint16 length) 
 *	2016 - stevstrong - reworked to automatically detect bit size from SPI setting
 */
 
-void SPIClass::dmaSendSet(void * transmitBuf, bool minc) {
+void SPIClass::dmaSendSet(const void * transmitBuf, bool minc) {
    uint32 flags = ( (DMA_MINC_MODE*minc) | DMA_FROM_MEM | DMA_TRNS_CMPLT);
    dma_init(_currentSetting->spiDmaDev);
    dma_xfer_size dma_bit_size = (_currentSetting->dataSize==DATA_SIZE_16BIT) ? DMA_SIZE_16BITS : DMA_SIZE_8BITS;
    dma_setup_transfer(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &_currentSetting->spi_d->regs->DR, dma_bit_size,
-                       transmitBuf, dma_bit_size, flags);// Transmit buffer DMA
+                       (volatile void*)transmitBuf, dma_bit_size, flags);// Transmit buffer DMA
    dma_set_priority(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, DMA_PRIORITY_LOW);
 }
 
@@ -498,12 +498,12 @@ uint8 SPIClass::dmaSendRepeat(uint16 length) {
     return b;
 }
 
-uint8 SPIClass::dmaSend(void * transmitBuf, uint16 length, bool minc) {
+uint8 SPIClass::dmaSend(const void * transmitBuf, uint16 length, bool minc) {
     dmaSendSet(transmitBuf, minc);
     return dmaSendRepeat(length);
 }
 
-uint8 SPIClass::dmaSendAsync(void * transmitBuf, uint16 length, bool minc) {
+uint8 SPIClass::dmaSendAsync(const void * transmitBuf, uint16 length, bool minc) {
     uint8 b = 0;	
 
     if (_currentSetting->state != SPI_STATE_READY)
@@ -529,7 +529,7 @@ uint8 SPIClass::dmaSendAsync(void * transmitBuf, uint16 length, bool minc) {
     // TX
     dma_xfer_size dma_bit_size = (_currentSetting->dataSize==DATA_SIZE_16BIT) ? DMA_SIZE_16BITS : DMA_SIZE_8BITS;
     dma_setup_transfer(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &_currentSetting->spi_d->regs->DR, dma_bit_size,
-    transmitBuf, dma_bit_size, flags);// Transmit buffer DMA 
+    (volatile void*)transmitBuf, dma_bit_size, flags);// Transmit buffer DMA 
     dma_set_num_transfers(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, length);
     dma_clear_isr_bits(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel);
     dma_enable(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel);// enable transmit

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -278,7 +278,7 @@ public:
      * @param buffer Bytes/words to transmit.
      * @param length Number of bytes/words in buffer to transmit.
      */
-    void write(void * buffer, uint32 length);
+    void write(const void * buffer, uint32 length);
 
     /**
      * @brief Transmit a byte, then return the next unread byte.
@@ -301,8 +301,8 @@ public:
      * @param receiveBuf buffer Bytes to save received data. 
      * @param length Number of bytes in buffer to transmit.
 	 */
-    uint8 dmaTransfer(void * transmitBuf, void * receiveBuf, uint16 length);
-    void dmaTransferSet(void *transmitBuf, void *receiveBuf);
+    uint8 dmaTransfer(const void * transmitBuf, void * receiveBuf, uint16 length);
+    void dmaTransferSet(const void *transmitBuf, void *receiveBuf);
     uint8 dmaTransferRepeat(uint16 length);
 
 	/**
@@ -315,11 +315,11 @@ public:
      * @param length Number of bytes in buffer to transmit.
 	 * @param minc Set to use Memory Increment mode, clear to use Circular mode.
      */
-    uint8 dmaSend(void * transmitBuf, uint16 length, bool minc = 1);
-    void dmaSendSet(void * transmitBuf, bool minc);
+    uint8 dmaSend(const void * transmitBuf, uint16 length, bool minc = 1);
+    void dmaSendSet(const void * transmitBuf, bool minc);
     uint8 dmaSendRepeat(uint16 length);
 
-    uint8 dmaSendAsync(void * transmitBuf, uint16 length, bool minc = 1);
+    uint8 dmaSendAsync(const void * transmitBuf, uint16 length, bool minc = 1);
     /*
      * Pin accessors
      */

--- a/STM32F4/libraries/SPI/src/SPI.cpp
+++ b/STM32F4/libraries/SPI/src/SPI.cpp
@@ -372,7 +372,7 @@ void SPIClass::write(uint16 data, uint32 n)
 	while ( (regs->SR & SPI_SR_BSY) != 0); // wait until BSY=0 before returning 
 }
 
-void SPIClass::write(void *data, uint32 length)
+void SPIClass::write(const void *data, uint32 length)
 {
 	spi_dev * spi_d = _currentSetting->spi_d;
 	spi_tx(spi_d, (void*)data, length); // data can be array of bytes or words
@@ -407,7 +407,7 @@ uint16_t SPIClass::transfer16(uint16_t wr_data) const
 *	On exit TX buffer is not modified, and RX buffer contains the received data.
 *	Still in progress.
 */
-uint8 SPIClass::dmaTransfer(void * transmitBuf, void * receiveBuf, uint16 length)
+uint8 SPIClass::dmaTransfer(const void * transmitBuf, void * receiveBuf, uint16 length)
 {
 	if (length == 0) return 0;
 
@@ -442,7 +442,7 @@ uint8 SPIClass::dmaTransfer(void * transmitBuf, void * receiveBuf, uint16 length
 						_currentSetting->spiDmaChannel,
 						dma_bit_size,
 						&_currentSetting->spi_d->regs->DR,	// peripheral address
-						transmitBuf,						// memory bank 0 address
+						(volatile void*)transmitBuf,						// memory bank 0 address
 						NULL,								// memory bank 1 address
 						flags
 	);
@@ -477,7 +477,7 @@ uint8 SPIClass::dmaTransfer(void * transmitBuf, void * receiveBuf, uint16 length
 *	Still in progress.
 *	2016 - stevstrong - reworked to automatically detect bit size from SPI setting
 */
-uint8 SPIClass::dmaSend(void * transmitBuf, uint16 length, bool minc)
+uint8 SPIClass::dmaSend(const void * transmitBuf, uint16 length, bool minc)
 {
 	if (length == 0) return 0;
 	uint8 b = 0;
@@ -489,7 +489,7 @@ uint8 SPIClass::dmaSend(void * transmitBuf, uint16 length, bool minc)
 						_currentSetting->spiDmaChannel,
 						dma_bit_size,
 						&_currentSetting->spi_d->regs->DR,	// peripheral address
-						transmitBuf,						// memory bank 0 address
+						(volatile void*)transmitBuf,						// memory bank 0 address
 						NULL,								// memory bank 1 address
 						( (DMA_MINC_MODE*minc) | DMA_FROM_MEM ) //| DMA_TRNS_CMPLT ) // flags
 	);// Transmit buffer DMA 

--- a/STM32F4/libraries/SPI/src/SPI.h
+++ b/STM32F4/libraries/SPI/src/SPI.h
@@ -248,7 +248,7 @@ public:
      * @param buffer Bytes/words to transmit.
      * @param length Number of bytes/words in buffer to transmit.
      */
-    void write(void * buffer, uint32 length);
+    void write(const void * buffer, uint32 length);
 
     /**
      * @brief Transmit a byte, then return the next unread byte.
@@ -272,7 +272,7 @@ public:
      * @param receiveBuf buffer Bytes to save received data. 
      * @param length Number of bytes in buffer to transmit.
 	 */
-	uint8 dmaTransfer(void * transmitBuf, void * receiveBuf, uint16 length);
+	uint8 dmaTransfer(const void * transmitBuf, void * receiveBuf, uint16 length);
 
 	/**
      * @brief Sets up a DMA Transmit for SPI 8 or 16 bit transfer mode.
@@ -283,7 +283,7 @@ public:
      * @param data buffer half words to transmit,
      * @param length Number of bytes in buffer to transmit.
      */
-	uint8 dmaSend(void * transmitBuf, uint16 length, bool minc = 1);
+	uint8 dmaSend(const void * transmitBuf, uint16 length, bool minc = 1);
 #endif
 
     /*


### PR DESCRIPTION
Add const qualifier to SPI member function arguments for write and transmit buffers.

Qualifying the write or transfer source buffer with const avoid compile errors or casting away const when calling a SPI member function with a const source buffer.

 

