### PR TITLE
Removed deprecated functionality from Print class for BYTE "base"

### DIFF
--- a/STM32F1/cores/maple/Print.cpp
+++ b/STM32F1/cores/maple/Print.cpp
@@ -99,10 +99,6 @@ size_t Print::print(unsigned long n, int base) {
 }
 
 size_t Print::print(long long n, int base) {
-    if (base == BYTE) 
-	{
-        return write((uint8)n);
-    }
     if (n < 0) {
         print('-');
         n = -n;
@@ -111,13 +107,7 @@ size_t Print::print(long long n, int base) {
 }
 
 size_t Print::print(unsigned long long n, int base) {
-size_t c=0;
-    if (base == BYTE) {
-        c= write((uint8)n);
-    } else {
-        c= printNumber(n, base);
-    }
-	return c;
+	return printNumber(n, base);
 }
 
 size_t Print::print(double n, int digits) {

--- a/STM32F1/cores/maple/Print.h
+++ b/STM32F1/cores/maple/Print.h
@@ -28,7 +28,6 @@
 #include "Printable.h"
 
 enum {
-    BYTE = 0,
     BIN  = 2,
     OCT  = 8,
     DEC  = 10,

--- a/STM32F1/libraries/A_STM32_Examples/examples/Communication/ASCIITable/ASCIITable.ino
+++ b/STM32F1/libraries/A_STM32_Examples/examples/Communication/ASCIITable/ASCIITable.ino
@@ -47,7 +47,7 @@ void loop() {
     // Prints value unaltered, i.e. the raw binary version of the
     // byte. The serial monitor interprets all bytes as
     // ASCII, so 33, the first number,  will show up as '!'
-    Serial.print(thisByte, BYTE);
+    Serial.write(thisByte);
 
     Serial.print(", dec: ");
     // Prints value as string as an ASCII-encoded decimal (base 10).

--- a/STM32F1/libraries/A_STM32_Examples/examples/Communication/MIDI/Midi.ino
+++ b/STM32F1/libraries/A_STM32_Examples/examples/Communication/MIDI/Midi.ino
@@ -44,8 +44,8 @@ void loop() {
 // Plays a MIDI note.  Doesn't check to see that cmd is greater than
 // 127, or that data values are less than 127:
 void noteOn(int cmd, int pitch, int velocity) {
-    Serial1.print(cmd, BYTE);
-    Serial1.print(pitch, BYTE);
-    Serial1.print(velocity, BYTE);
+    Serial1.write(cmd);
+    Serial1.write(pitch);
+    Serial1.write(velocity);
 }
 

--- a/STM32F1/libraries/A_STM32_Examples/examples/Communication/SerialCallResponse/SerialCallResponse.ino
+++ b/STM32F1/libraries/A_STM32_Examples/examples/Communication/SerialCallResponse/SerialCallResponse.ino
@@ -50,15 +50,15 @@ void loop() {
         // read switch, map it to 0 or 255
         thirdSensor = map(digitalRead(2), 0, 1, 0, 255);
         // send sensor values:
-        Serial.print(firstSensor, BYTE);
-        Serial.print(secondSensor, BYTE);
-        Serial.print(thirdSensor, BYTE);
+        Serial.write(firstSensor);
+        Serial.write(secondSensor);
+        Serial.write(thirdSensor);
     }
 }
 
 void establishContact() {
     while (Serial.available() <= 0) {
-        Serial.print('A', BYTE);   // send a capital A
+        Serial.write('A');   // send a capital A
         delay(300);
     }
 }

--- a/STM32F1/libraries/A_STM32_Examples/examples/Communication/SerialPassthrough/SerialPassthrough.ino
+++ b/STM32F1/libraries/A_STM32_Examples/examples/Communication/SerialPassthrough/SerialPassthrough.ino
@@ -26,6 +26,6 @@ void loop() {
     // Read from Serial1, send over USB on Maple (or uses hardware serial 1 and hardware serial 2 on non-maple boards:
     if (Serial1.available()) {
         inByte = Serial1.read();
-        Serial.print(inByte, BYTE);
+        Serial.write(inByte);
     }
 }

--- a/STM32F1/libraries/A_STM32_Examples/examples/General/USB_ASCII/USB_ASCII.ino
+++ b/STM32F1/libraries/A_STM32_Examples/examples/General/USB_ASCII/USB_ASCII.ino
@@ -67,7 +67,7 @@ void loop() {
     // Prints value unaltered, i.e. the raw binary version of the
     // byte. The serial monitor interprets all bytes as
     // ASCII, so 33, the first number,  will show up as '!'
-    Serial.print(thisByte, BYTE);
+    Serial.write(thisByte);
 
     Serial.print(", dec: ");
     // Prints value as string as an ASCII-encoded decimal (base 10).

--- a/STM32F3/cores/maple/wirish/Print.cpp
+++ b/STM32F3/cores/maple/wirish/Print.cpp
@@ -88,10 +88,6 @@ void Print::print(unsigned long n, int base) {
 }
 
 void Print::print(long long n, int base) {
-    if (base == BYTE) {
-        write((uint8)n);
-        return;
-    }
     if (n < 0) {
         print('-');
         n = -n;
@@ -100,11 +96,7 @@ void Print::print(long long n, int base) {
 }
 
 void Print::print(unsigned long long n, int base) {
-    if (base == BYTE) {
-        write((uint8)n);
-    } else {
-        printNumber(n, base);
-    }
+    printNumber(n, base);
 }
 
 void Print::print(double n, int digits) {

--- a/STM32F3/cores/maple/wirish/Print.h
+++ b/STM32F3/cores/maple/wirish/Print.h
@@ -26,7 +26,6 @@
 #include <libmaple/libmaple_types.h>
 
 enum {
-    BYTE = 0,
     BIN  = 2,
     OCT  = 8,
     DEC  = 10,

--- a/STM32F4/cores/maple/Print.cpp
+++ b/STM32F4/cores/maple/Print.cpp
@@ -99,10 +99,6 @@ size_t Print::print(unsigned long n, int base) {
 }
 
 size_t Print::print(long long n, int base) {
-    if (base == BYTE) 
-	{
-        return write((uint8)n);
-    }
     if (n < 0) {
         print('-');
         n = -n;
@@ -111,13 +107,7 @@ size_t Print::print(long long n, int base) {
 }
 
 size_t Print::print(unsigned long long n, int base) {
-size_t c=0;
-    if (base == BYTE) {
-        c= write((uint8)n);
-    } else {
-        c= printNumber(n, base);
-    }
-	return c;
+	return printNumber(n, base);
 }
 
 size_t Print::print(double n, int digits) {

--- a/STM32F4/cores/maple/Print.h
+++ b/STM32F4/cores/maple/Print.h
@@ -28,7 +28,6 @@
 #include "Printable.h"
 
 enum {
-    BYTE = 0,
     BIN  = 2,
     OCT  = 8,
     DEC  = 10,


### PR DESCRIPTION
Several sketches:
- ASCIITable.ino
- Midi.ino
- SerialCallResponse.ino
- SerialPassthrough.ino
- USB_ASCII.ino

make use of the deprecated Serial.print(value, BYTE).
This can be replaced by Serial.write() in the sketches, seems only to be used in these sketches and results in conflicts when BYTE is defined as something else e.g. in the Elm-chan FatFS library.

Please consider this pull request as a small cleanup operation.