### PR TITLE
Fixing readTemp unit conversions

### DIFF
--- a/STM32F1/libraries/STM32ADC/src/STM32ADC.cpp
+++ b/STM32F1/libraries/STM32ADC/src/STM32ADC.cpp
@@ -67,8 +67,11 @@
     float STM32ADC::readTemp(){
         unsigned int result = 0;
         float temperature = 0.0;
-        result = adc_read(_dev, 16);
-        temperature = (float)((_V25-result)/_AverageSlope)+ 25.0; 
+        result = adc_read(_dev, 16); // raw ADC value
+        // ADC inputs are 0.0V to 3.6V
+        // ADC has 12 bit or resolution
+		float vsense = (3.6f/4096.0f) * (float)result; // Volts
+		temperature = (float)(((_V25 - vsense) * 1000.0) / _AverageSlope) + 25.0; // (((V25 - VSense) in mV)/ (AverageSlope in mV/degC)) + 25
         return temperature;
     }
 


### PR DESCRIPTION
The original not doing any unit conversions. For example let result=1700: 
   (1.54V - 1700unitless) / (4.34 mV/C) + 25C
This now converts the numerator to mV assuming STM32F103XXXX has a 12 bit ADC  and ranges from 0V to 3.6V.
Also the VCC should be changed too. I'm not sure where the 1.1 scale factor came from.

Can someone create an example to use this function with polling. I have tried and it causes my cpu board to hang. OLIMEXINO-STM32 development board

STM32F103X8
STM32F103XB
Datasheet
http://www.st.com/content/ccc/resource/technical/document/datasheet/33/d4/6f/1d/df/0b/4c/6d/CD00161566.pdf/files/CD00161566.pdf/jcr:content/translations/en.CD00161566.pdf