### PR TITLE
Solve race condition with arduino IDE monitoring serial port

### DIFF
--- a/tools/linux/maple_upload
+++ b/tools/linux/maple_upload
@@ -42,7 +42,7 @@ fi
 echo -n Waiting for ${dummy_port_fullpath} serial...
 
 COUNTER=0
-while [ ! -c ${dummy_port_fullpath} ] && ((COUNTER++ < 40)); do
+while [ ! -r ${dummy_port_fullpath} ] && ((COUNTER++ < 40)); do
     sleep 0.1
 done
 


### PR DESCRIPTION
I encountered a race condition upon which, even though the udev rules were working and uploads succeed, the serial monitor can not re-establish communications.

If the serial monitor is left open when doing an upload the error shown is:

[...]
Copying data from PC to DFU device
Starting download: [##################################################] finished!
state(8) = dfuMANIFEST-WAIT-RESET, status(0) = No error condition is present
Done!
Resetting USB to switch back to runtime mode
Waiting for /dev/ttyACM0 serial...Done
processing.app.SerialException: Error opening serial port '/dev/ttyACM0'. Try consulting the documentation at http://playground.arduino.cc/Linux/All#Permission
	at processing.app.Serial.<init>(Serial.java:145)
	at processing.app.Serial.<init>(Serial.java:82)
	at processing.app.SerialMonitor$4.<init>(SerialMonitor.java:101)
	at processing.app.SerialMonitor.open(SerialMonitor.java:101)
	at processing.app.AbstractMonitor.resume(AbstractMonitor.java:104)
	at processing.app.Editor.resumeOrCloseSerialMonitor(Editor.java:2218)
	at processing.app.Editor.access$2200(Editor.java:79)
	at processing.app.Editor$DefaultExportHandler.run(Editor.java:2196)
	at java.lang.Thread.run(Thread.java:748)
Error opening serial port '/dev/ttyACM0'. Try consulting the documentation at http://playground.arduino.cc/Linux/All#Permission

I traced it to the device being opened prior to the permissions/ownership changes.

When testing via -c the upload script waits for the character device creation, but at that point the udev rules have not changed the permissions. By testing the readability of the device via the -r test, we wait until the new permissions have been applied.

I imagine this is specific to the Linux kernel and the speed of the machine being used. In my case:
arduino-1.8.5
Linux 4.4.0-98-generic #121-Ubuntu SMP
but the change should work on any system with proper udev rules / permissions.