### PR TITLE
Fixed 'warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

### DIFF
--- a/STM32F1/cores/maple/libmaple/rcc.c
+++ b/STM32F1/cores/maple/libmaple/rcc.c
@@ -61,7 +61,7 @@ void rcc_switch_sysclk(rcc_sysclk_src sysclk_src) {
     RCC_BASE->CFGR = cfgr;
 
     /* Wait for new source to come into use. */
-    while ((RCC_BASE->CFGR & RCC_CFGR_SWS) != (sysclk_src << 2))
+    while ((RCC_BASE->CFGR & RCC_CFGR_SWS) != (unsigned int)(sysclk_src << 2))
         ;
 }
 

--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -487,7 +487,7 @@ uint32 usb_cdcacm_rx(uint8* buf, uint32 len)
  * Looks at unread bytes without marking them as read. */
 uint32 usb_cdcacm_peek(uint8* buf, uint32 len)
 {
-    int i;
+    uint32 i;
     uint32 tail = rx_tail;
 	uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
@@ -505,7 +505,7 @@ uint32 usb_cdcacm_peek(uint8* buf, uint32 len)
 
 uint32 usb_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
-    int i;
+    uint32 i;
     uint32 tail = (rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
 	uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
@@ -583,7 +583,7 @@ static void vcomDataTxCb(void)
 	uint32 *dst = usb_pma_ptr(USB_CDCACM_TX_ADDR);
     uint16 tmp = 0;
 	uint16 val;
-	int i;
+	uint32 i;
 	for (i = 0; i < tx_unsent; i++) {
 		val = vcomBufferTx[tail];
 		tail = (tail + 1) & CDC_SERIAL_TX_BUFFER_SIZE_MASK;

--- a/STM32F1/libraries/OLED_I2C/OLED_I2C.cpp
+++ b/STM32F1/libraries/OLED_I2C/OLED_I2C.cpp
@@ -283,7 +283,7 @@ void OLED::printNumF(double num, byte dec, int x, int y, char divider, int lengt
 
 	if (divider != '.')
 	{
-		for (int i=0; i<sizeof(st); i++)
+		for (size_t i=0; i<sizeof(st); i++)
 			if (st[i]=='.')
 				st[i]=divider;
 	}
@@ -293,13 +293,13 @@ void OLED::printNumF(double num, byte dec, int x, int y, char divider, int lengt
 		if (neg)
 		{
 			st[0]='-';
-			for (int i=1; i<sizeof(st); i++)
+			for (size_t i=1; i<sizeof(st); i++)
 				if ((st[i]==' ') || (st[i]=='-'))
 					st[i]=filler;
 		}
 		else
 		{
-			for (int i=0; i<sizeof(st); i++)
+			for (size_t i=0; i<sizeof(st); i++)
 				if (st[i]==' ')
 					st[i]=filler;
 		}

--- a/STM32F1/variants/STM32VLD/wirish/syscalls.c
+++ b/STM32F1/variants/STM32VLD/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/generic_gd32f103c/wirish/syscalls.c
+++ b/STM32F1/variants/generic_gd32f103c/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/generic_stm32f103c/wirish/syscalls.c
+++ b/STM32F1/variants/generic_stm32f103c/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/generic_stm32f103r8/wirish/syscalls.c
+++ b/STM32F1/variants/generic_stm32f103r8/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/generic_stm32f103t/wirish/syscalls.c
+++ b/STM32F1/variants/generic_stm32f103t/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/generic_stm32f103v/wirish/syscalls.c
+++ b/STM32F1/variants/generic_stm32f103v/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/generic_stm32f103z/wirish/syscalls.c
+++ b/STM32F1/variants/generic_stm32f103z/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/hytiny_stm32f103t/wirish/syscalls.c
+++ b/STM32F1/variants/hytiny_stm32f103t/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/maple/wirish/syscalls.c
+++ b/STM32F1/variants/maple/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/maple_mini/wirish/syscalls.c
+++ b/STM32F1/variants/maple_mini/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/maple_ret6/wirish/syscalls.c
+++ b/STM32F1/variants/maple_ret6/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/microduino/wirish/syscalls.c
+++ b/STM32F1/variants/microduino/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F1/variants/nucleo_f103rb/wirish/syscalls.c
+++ b/STM32F1/variants/nucleo_f103rb/wirish/syscalls.c
@@ -156,7 +156,7 @@ __weak void cgets(char *s, int bufsize) {
 }
 
 __weak int _write(int fd __attribute__((unused)), const char *buf, size_t cnt) {
-    int i;
+    size_t i;
 
     for (i = 0; i < cnt; i++)
         putch(buf[i]);

--- a/STM32F3/cores/maple/libmaple/rcc.c
+++ b/STM32F3/cores/maple/libmaple/rcc.c
@@ -61,7 +61,7 @@ void rcc_switch_sysclk(rcc_sysclk_src sysclk_src) {
     RCC_BASE->CFGR = cfgr;
 
     /* Wait for new source to come into use. */
-    while ((RCC_BASE->CFGR & RCC_CFGR_SWS) != (sysclk_src << 2))
+    while ((RCC_BASE->CFGR & RCC_CFGR_SWS) != (unsigned int)(sysclk_src << 2))
         ;
 }
 


### PR DESCRIPTION
Same as #274 but only fixing -Wsign-compare.

Most of these fixes are self explanatory.

The question is if `rcc_sysclk_src<<2` should be type-casted to `uint32` or `unsigned int`, as I did.

```
typedef enum rcc_sysclk_src {
    RCC_CLKSRC_HSI = 0x0,
    RCC_CLKSRC_HSE = 0x1,
    RCC_CLKSRC_PLL = 0x2,
} rcc_sysclk_src;

```

