### PR TITLE
Replace hackish EEPROM size/location determination with something smarter

### DIFF
--- a/STM32F1/libraries/EEPROM/EEPROM.cpp
+++ b/STM32F1/libraries/EEPROM/EEPROM.cpp
@@ -1,6 +1,22 @@
 #include "EEPROM.h"
 // See http://www.st.com/web/en/resource/technical/document/application_note/CD00165693.pdf
 
+static const uint32_t flashSize =
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 768*1024 ? 1024*1024 : 
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 512*1024 ? 768*1024 : 
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 384*1024 ? 512*1024 : 
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 256*1024 ? 384*1024 : 
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 128*1024 ? 256*1024 : 
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 64*1024 ? 128*1024 : 
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 32*1024 ? 64*1024 : 
+    ARDUINO_UPLOAD_MAXIMUM_SIZE > 16*1024 ? 32*1024 : 
+    16*1024;
+    
+static const uint32_t eepromPageSize = flashSize <= 128*1024 ? 1024 : 2048;
+static const uint32_t eepromStartAddress = 0x8000000 + flashSize - 2 * eepromPageSize;
+static const uint32_t eepromPage0Base = eepromStartAddress;
+static const uint32_t eepromPage1Base = eepromStartAddress + eepromPageSize;
+
 /**
   * @brief  Check page for blank
   * @param  page base address
@@ -281,9 +297,9 @@ uint16 EEPROMClass::EE_VerifyPageFullWriteVariable(uint16 Address, uint16 Data)
 
 EEPROMClass::EEPROMClass(void)
 {
-	PageBase0 = EEPROM_PAGE0_BASE;
-	PageBase1 = EEPROM_PAGE1_BASE;
-	PageSize = EEPROM_PAGE_SIZE;
+	PageBase0 = eepromPage0Base;
+	PageBase1 = eepromPage1Base;
+	PageSize = eepromPageSize;
 	Status = EEPROM_NOT_INIT;
 }
 

--- a/STM32F1/libraries/EEPROM/EEPROM.h
+++ b/STM32F1/libraries/EEPROM/EEPROM.h
@@ -4,36 +4,6 @@
 #include <wirish.h>
 #include "flash_stm32.h"
 
-// HACK ALERT. This definition may not match your processor
-// To Do. Work out correct value for EEPROM_PAGE_SIZE on the STM32F103CT6 etc 
-#define MCU_STM32F103RB
-
-#ifndef EEPROM_PAGE_SIZE
-	#if defined (MCU_STM32F103RB)
-		#define EEPROM_PAGE_SIZE	(uint16)0x400  /* Page size = 1KByte */
-	#elif defined (MCU_STM32F103ZE) || defined (MCU_STM32F103RE) || defined (MCU_STM32F103RD)
-		#define EEPROM_PAGE_SIZE	(uint16)0x800  /* Page size = 2KByte */
-	#else
-		#error	"No MCU type specified. Add something like -DMCU_STM32F103RB to your compiler arguments (probably in a Makefile)."
-	#endif
-#endif
-
-#ifndef EEPROM_START_ADDRESS
-	#if defined (MCU_STM32F103RB)
-		#define EEPROM_START_ADDRESS	((uint32)(0x8000000 + 128 * 1024 - 2 * EEPROM_PAGE_SIZE))
-	#elif defined (MCU_STM32F103ZE) || defined (MCU_STM32F103RE)
-		#define EEPROM_START_ADDRESS	((uint32)(0x8000000 + 512 * 1024 - 2 * EEPROM_PAGE_SIZE))
-	#elif defined (MCU_STM32F103RD)
-		#define EEPROM_START_ADDRESS	((uint32)(0x8000000 + 384 * 1024 - 2 * EEPROM_PAGE_SIZE))
-	#else
-		#error	"No MCU type specified. Add something like -DMCU_STM32F103RB to your compiler arguments (probably in a Makefile)."
-	#endif
-#endif
-
-/* Pages 0 and 1 base and end addresses */
-#define EEPROM_PAGE0_BASE		((uint32)(EEPROM_START_ADDRESS + 0x000))
-#define EEPROM_PAGE1_BASE		((uint32)(EEPROM_START_ADDRESS + EEPROM_PAGE_SIZE))
-
 /* Page status definitions */
 #define EEPROM_ERASED			((uint16)0xFFFF)	/* PAGE is empty */
 #define EEPROM_RECEIVE_DATA		((uint16)0xEEEE)	/* PAGE is marked to receive data */

--- a/STM32F1/platform.txt
+++ b/STM32F1/platform.txt
@@ -75,13 +75,13 @@ compiler.libs.c.flags="-I{build.system.path}/libmaple" "-I{build.system.path}/li
 # ---------------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.libs.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_UPLOAD_MAXIMUM_SIZE={upload.maximum_size} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.libs.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.cpu_flags} {build.hs_flag} {build.common_flags} {compiler.libs.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_UPLOAD_MAXIMUM_SIZE={upload.maximum_size} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.cpu_flags} {build.hs_flag} {build.common_flags} {compiler.libs.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.cpu_flags} {build.hs_flag} {build.common_flags} {compiler.libs.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mcpu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_UPLOAD_MAXIMUM_SIZE={upload.maximum_size} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.cpu_flags} {build.hs_flag} {build.common_flags} {compiler.libs.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"


### PR DESCRIPTION
The EEPROM size/location determination only worked on F1 boards with 128K flash. On boards with less flash, the EEPROM would be outside the address space, and on boards with more flash the EEPROM could overwrite code. (Well, that can still happen if the code size is big enough.)

The PR uses the upload size to figure out the flash size and page size.