### PR TITLE
Correct a bug in FreeRTOS

### DIFF
--- a/STM32F1/libraries/FreeRTOS900/utility/FreeRTOS.h
+++ b/STM32F1/libraries/FreeRTOS900/utility/FreeRTOS.h
@@ -948,6 +948,9 @@ typedef struct xSTATIC_TCB
 	#if( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
 		uint8_t			uxDummy20;
 	#endif
+	#if( INCLUDE_xTaskAbortDelay == 1 )
+		uint8_t ucDummy21;
+	#endif
 
 } StaticTask_t;
 


### PR DESCRIPTION
As listed in https://www.freertos.org/a00104.html#mailing_list:
"The definition of the StaticTask_t structure is incorrect if INCLUDE_xTaskAbortDelay is set to 1, or the MPU is used. The corrected structure definition can be obtained from here."
https://sourceforge.net/p/freertos/code/HEAD/tree/trunk/FreeRTOS/Source/include/FreeRTOS.h#l978