### PR TITLE
Add timer input capture for STM32F1

### DIFF
--- a/STM32F1/cores/maple/HardwareTimer.cpp
+++ b/STM32F1/cores/maple/HardwareTimer.cpp
@@ -176,7 +176,17 @@ void HardwareTimer::setMasterModeTrGo(uint32_t mode) {
     
 
 //set the polarity of counting... not sure how interesting this is.. 
-    void HardwareTimer::setPolarity(){} 
+    void HardwareTimer::setPolarity(){}
+
+
+bool HardwareTimer::getInputOvercapture(int channel) {
+    return timer_cc_get_overcapture(this->dev, (uint8)channel) == 1;
+}
+
+void HardwareTimer::setInputCapturePolarity(int channel, ExtIntTriggerMode polarity) {
+    timer_cc_set_pol(this->dev, (uint8)channel, polarity == FALLING ? 1 : 0);
+}
+
 
 /* -- Deprecated predefined instances -------------------------------------- */
 

--- a/STM32F1/cores/maple/HardwareTimer.h
+++ b/STM32F1/cores/maple/HardwareTimer.h
@@ -34,6 +34,7 @@
 // TODO [0.1.0] Remove deprecated pieces, pick a better API
 
 #include <libmaple/timer.h>
+#include "ext_interrupts.h"
 
 /** Timer mode. */
 typedef timer_mode TimerMode;
@@ -243,6 +244,24 @@ public:
     void setPolarity();
     
 //add the filtering definition for the input channel.
+    
+    
+    /**
+     * @brief Get the overcapture flag of the
+     *        corresponding input capture channel.
+     * @param channel Timer channel, from 1 to 4.
+     * @return true if overcapture occured, false otherwise.
+     */
+    bool getInputOvercapture(int channel);
+    
+    /**
+     * @brief Set the capture polarity for the
+     *        corresponding input capture channel.
+     * @param channel Timer channel, from 1 to 4.
+     * @param polarity RISING to capture on rising edge,
+     *                 FALLING to capture on falling edge.
+     */
+    void setInputCapturePolarity(int channel, ExtIntTriggerMode polarity);
     
 
     /* Escape hatch */

--- a/STM32F1/cores/maple/libmaple/timer.c
+++ b/STM32F1/cores/maple/libmaple/timer.c
@@ -39,6 +39,7 @@ static void disable_channel(timer_dev *dev, uint8 channel);
 static void pwm_mode(timer_dev *dev, uint8 channel);
 static void output_compare_mode(timer_dev *dev, uint8 channel);
 static void encoder_mode(timer_dev *dev, uint8 channel) ;//CARLOS
+static void input_capture_mode(timer_dev *dev, uint8 channel);
 
 
 static inline void enable_irq(timer_dev *dev, timer_interrupt_id iid);
@@ -236,6 +237,9 @@ void timer_set_mode(timer_dev *dev, uint8 channel, timer_mode mode) {
     case TIMER_ENCODER: 
         encoder_mode(dev, channel); //find a way to pass all the needed stuff on the 8bit var
         break;
+    case TIMER_INPUT_CAPTURE:
+        input_capture_mode(dev, channel);
+        break;
     }
 }
 
@@ -304,6 +308,11 @@ uint8 get_direction(timer_dev *dev){
     return *bb_perip(&(dev->regs).gen->CR1, TIMER_CR1_DIR_BIT);
 }
 
+// Enable default input capture mode
+static void input_capture_mode(timer_dev *dev, uint8 channel) {
+    timer_oc_set_mode(dev, channel, 0, TIMER_CCMR_CCS_INPUT_TI1);
+    timer_cc_enable(dev, channel);
+}
 
 
 /*

--- a/STM32F1/system/libmaple/include/libmaple/timer.h
+++ b/STM32F1/system/libmaple/include/libmaple/timer.h
@@ -564,8 +564,11 @@ typedef enum timer_mode {
      * values, the corresponding interrupt is fired. */
     TIMER_OUTPUT_COMPARE,
 
-    /* TIMER_INPUT_CAPTURE, TODO: In this mode, the timer can measure the
-     *                            pulse lengths of input signals */
+    /**
+     * In this mode, the timer can measure the
+     * pulse lengths of input signals */
+    TIMER_INPUT_CAPTURE,
+    
     /* TIMER_ONE_PULSE, TODO: In this mode, the timer can generate a single
      *                        pulse on a GPIO pin for a specified amount of
      *                        time. */
@@ -901,6 +904,16 @@ static inline void timer_cc_set_pol(timer_dev *dev, uint8 channel, uint8 pol) {
     *bb_perip(&(dev->regs).gen->CCER, 4 * (channel - 1) + 1) = pol;
 }
 
+/**
+ * @brief Get a channel's overcapture flag.
+ * @param dev Timer device, must have type TIMER_ADVANCED or TIMER_GENERAL.
+ * @param channel Channel whose overcapture flag to get.
+ * @return Overcapture flag, either 0 or 1.
+ */
+static inline uint8 timer_cc_get_overcapture(timer_dev *dev, uint8 channel) {
+    return *bb_perip(&(dev->regs).gen->SR, (channel-1) + 9);
+}
+    
 /**
  * @brief Get a timer's DMA burst length.
  * @param dev Timer device, must have type TIMER_ADVANCED or TIMER_GENERAL.


### PR DESCRIPTION
Implements timer input capture on HardwareTimer class for STM32F1 boards.
Based on http://www.stm32duino.com/viewtopic.php?f=3&t=1029