### PR TITLE
SPI.h: remove unused variable warnings

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -86,6 +86,11 @@ static const spi_pins board_spi_pins[] __FLASH__ = {
 #endif
 };
 
+static void (*_spi1_this);
+static void (*_spi2_this);
+#if BOARD_NR_SPI >= 3
+  static void (*_spi3_this);
+#endif
 
 /*
  * Constructor
@@ -399,8 +404,9 @@ void SPIClass::dmaTransferSet(const void *transmitBuf, void *receiveBuf) {
     dma_setup_transfer(_currentSetting->spiDmaDev, _currentSetting->spiRxDmaChannel, &_currentSetting->spi_d->regs->DR, dma_bit_size,
                      receiveBuf, dma_bit_size, (DMA_MINC_MODE | DMA_TRNS_CMPLT ));// receive buffer DMA
     if (!transmitBuf) {
-    transmitBuf = &ff;
-    dma_setup_transfer(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &_currentSetting->spi_d->regs->DR, dma_bit_size,
+        static uint8_t ff = 0XFF;
+        transmitBuf = &ff;
+        dma_setup_transfer(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &_currentSetting->spi_d->regs->DR, dma_bit_size,
                        (volatile void*)transmitBuf, dma_bit_size, (DMA_FROM_MEM));// Transmit FF repeatedly
     }
     else {

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -160,11 +160,11 @@ private:
 /*
     Should move this to within the class once tested out, just for tidyness
 */
-static uint8_t ff = 0XFF;
-static void (*_spi1_this);
-static void (*_spi2_this);
+static uint8_t __attribute__ ((unused)) ff = 0XFF;
+static void __attribute__ ((unused)) (*_spi1_this);
+static void __attribute__ ((unused)) (*_spi2_this);
 #if BOARD_NR_SPI >= 3
-static void (*_spi3_this);
+static void __attribute__ ((unused)) (*_spi3_this);
 #endif
 
 /**

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -156,17 +156,6 @@ private:
 	friend class SPIClass;
 };
 
-
-/*
-    Should move this to within the class once tested out, just for tidyness
-*/
-static uint8_t __attribute__ ((unused)) ff = 0XFF;
-static void __attribute__ ((unused)) (*_spi1_this);
-static void __attribute__ ((unused)) (*_spi2_this);
-#if BOARD_NR_SPI >= 3
-static void __attribute__ ((unused)) (*_spi3_this);
-#endif
-
 /**
  * @brief Wirish SPI interface.
  *


### PR DESCRIPTION
Small change to get rid of the annoying false positive unused warnings.