### PR TITLE
use Adafruit_GFX instead Adafruit_GFX_AS

### DIFF
--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
@@ -7,7 +7,7 @@ This library has been modified for the Maple Mini
 #define _ADAFRUIT_ILI9341H_
 
 #include "Arduino.h"
-#include <Adafruit_GFX_AS.h>
+#include <Adafruit_GFX.h>
 #include <SPI.h>
 
 #ifndef swap

--- a/STM32F1/libraries/RTClock/src/rtc_util.c
+++ b/STM32F1/libraries/RTClock/src/rtc_util.c
@@ -1,0 +1,253 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2012 LeafLabs, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ * @file   rtc.c
+ * @author Rod Gilchrist <rod@visibleassets.com>
+ * @brief  Real Time Clock interface
+ */
+
+#include "rtc_util.h"
+
+
+#define NR_RTC_HANDLERS                 4
+
+static rtc_dev rtc = {
+    .regs         = RTC_BASE,
+    .handlers     = { [NR_RTC_HANDLERS - 1] = 0 },
+};
+
+rtc_dev *RTC = &rtc;
+
+
+/**
+ * Initialize the RTC interface, and enable access to its register map and 
+ * the backup registers.
+ */
+void rtc_init(rtc_clk_src src) {
+
+	bkp_init();		// turn on peripheral clocks to PWR and BKP and reset the backup domain via RCC registers.
+					// (we reset the backup domain here because we must in order to change the rtc clock source).
+
+	bkp_enable_writes();	// enable writes to the backup registers and the RTC registers via the DBP bit in the PWR control register
+	//////////////////////   flush backup area
+	RCC_BASE->BDCR |= RCC_BDCR_RTCSEL;
+	RCC_BASE->BDCR &= ~RCC_BDCR_RTCSEL;
+	switch (src) {
+		case RTCSEL_NONE:
+			RCC_BASE->BDCR = RCC_BDCR_RTCSEL_NONE;
+			break;
+
+		case RTCSEL_LSE:
+			rcc_start_lse();
+			RCC_BASE->BDCR |= RCC_BDCR_RTCSEL_LSE;
+
+			break;
+
+		case RTCSEL_LSI:
+		case RTCSEL_DEFAULT:
+			rcc_start_lsi();
+			RCC_BASE->BDCR |= RCC_BDCR_RTCSEL_LSI;
+			break;
+
+		case RTCSEL_HSE:			// This selection uses HSE/128 as the RTC source (i.e. 64 kHz with an 8 mHz xtal)
+			rcc_start_hse();
+			RCC_BASE->BDCR |= RCC_BDCR_RTCSEL_HSE;
+			break;
+	}
+	bb_peri_set_bit(&RCC_BASE->BDCR, RCC_BDCR_RTCEN_BIT, 1); // Enable the RTC
+
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+}
+
+/**
+ * @brief Attach a RTC interrupt.
+ * @param interrupt Interrupt number to attach to; this may be any rtc_interrupt_id.
+ * @param handler Handler to attach to the given interrupt.
+ * @see rtc_interrupt_id
+ */
+void rtc_attach_interrupt(	uint8 interrupt,
+                            voidFuncPtr handler) {
+    RTC->handlers[interrupt] = handler;
+    rtc_enable_irq(interrupt);
+	switch (interrupt) {
+		case RTC_SECONDS_INTERRUPT: nvic_irq_enable(NVIC_RTC); break;
+		case RTC_OVERFLOW_INTERRUPT: nvic_irq_enable(NVIC_RTC); break;
+		case RTC_ALARM_GLOBAL_INTERRUPT: nvic_irq_enable(NVIC_RTC); break;
+		case RTC_ALARM_SPECIFIC_INTERRUPT: nvic_irq_enable(NVIC_RTCALARM); break; // The alarm specific interrupt can wake us from deep sleep.
+	}
+}
+
+/**
+ * @brief Detach an rtc interrupt.
+ * @param interrupt Interrupt number to detach.
+ * @see rtc_interrupt_id
+ */
+void rtc_detach_interrupt(uint8 interrupt) {
+	rtc_disable_irq(interrupt);
+    RTC->handlers[interrupt] = NULL;
+}
+
+/*
+ * IRQ handlers
+ */
+
+/* For dispatch routines which service multiple interrupts. */
+#define handle_irq(dier_sr, irq_mask, handlers, iid, handled_irq) do {  \
+	if ((dier_sr) & (irq_mask)) {                                   \
+		void (*__handler)(void) = (handlers)[iid];                  \
+		if (__handler) {                                            \
+			__handler();                                            \
+			handled_irq |= (irq_mask);                              \
+		}                                                           \
+	}                                                               \
+} while (0)
+
+static inline void dispatch_multiple_rtc_irq() {
+    rtc_reg_map *regs = RTC->regs;
+    uint32 dsr = regs->CRH & regs->CRL;
+    void (**hs)(void) = RTC->handlers;
+    uint32 handled = 0;
+
+    handle_irq(dsr, RTC_CRL_SECF, hs, RTC_SECONDS_INTERRUPT, handled);
+    handle_irq(dsr, RTC_CRL_ALRF, hs, RTC_ALARM_GLOBAL_INTERRUPT, handled);
+    handle_irq(dsr, RTC_CRL_OWF, hs, RTC_OVERFLOW_INTERRUPT, handled);
+
+    regs->CRL &= ~handled;
+}
+
+void __irq_rtc(void) {
+    dispatch_multiple_rtc_irq();
+}
+
+/* A special-case dispatch routine for single-interrupt NVIC lines.
+ * This function assumes that the interrupt corresponding to `RTC_ALARM_INTERRUPT' has
+ * in fact occurred (i.e., it doesn't check DIER & SR). */
+void __irq_rtcalarm(void) {
+    void (*handler)(void) = RTC->handlers[RTC_ALARM_SPECIFIC_INTERRUPT];
+    if (handler) {
+        handler();
+		*bb_perip(&EXTI_BASE->PR, EXTI_RTC_ALARM_BIT) = 1;
+		//asm volatile("nop");		// See comment in exti.c. Doesn't seem to be required.
+		//asm volatile("nop");
+    }
+}
+
+/**
+ * @brief Returns the rtc's counter (i.e. time/date) value.
+ *
+ * This value is likely to be inaccurate if the counter is running
+ * with a low prescaler.
+ */
+uint32 rtc_get_count() {
+	uint32 h, l;
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	h = RTC->regs->CNTH & 0xffff;
+	l = RTC->regs->CNTL & 0xffff;
+	return (h << 16) | l;
+}
+
+/**
+ * @brief Sets the counter value (i.e. time/date) for the rtc.
+ * @param value New counter value
+ */
+void rtc_set_count(uint32 value) {
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	rtc_enter_config_mode();
+	RTC->regs->CNTH = (value >> 16) & 0xffff;
+	RTC->regs->CNTL = value & 0xffff;
+	rtc_exit_config_mode();
+	rtc_wait_finished();
+}
+
+/**
+ * @brief Sets the prescaler load value for the rtc.
+ * @param value New prescaler load value (use 0x7fff to get 1 second period with 32.768 Hz clock).
+ */
+void rtc_set_prescaler_load(uint32 value) {
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	rtc_enter_config_mode();
+	RTC->regs->PRLH = (value >> 16) & 0xffff;
+	RTC->regs->PRLL = value & 0xffff;
+	rtc_exit_config_mode();
+	rtc_wait_finished();
+}
+
+void rtc_enable_calibration(void){
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	rtc_enter_config_mode();
+	bb_peri_set_bit(&BKP_BASE->RTCCR, BKP_RTCCR_CCO_BIT, 1);
+	rtc_exit_config_mode();
+	rtc_wait_finished();
+}
+void rtc_disable_calibration(void){
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	rtc_enter_config_mode();
+	bb_peri_set_bit(&BKP_BASE->RTCCR, BKP_RTCCR_CCO_BIT, 0);
+	rtc_exit_config_mode();
+	rtc_wait_finished();
+}
+
+
+/**
+ * @brief Returns the rtc's prescaler divider (i.e. current divider count) value.
+ */
+uint32 rtc_get_divider() {
+	uint32 h, l;
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	h = RTC->regs->DIVH & 0x000f;
+	l = RTC->regs->DIVL & 0xffff;
+	return (h << 16) | l;
+}
+
+/**
+ * @brief Sets the alarm value (i.e. time/date) for the rtc.
+ * @param value New alarm value
+ */
+void rtc_set_alarm(uint32 value) {
+	rtc_clear_sync();
+	rtc_wait_sync();
+	rtc_wait_finished();
+	rtc_enter_config_mode();
+	RTC->regs->ALRH = (value >> 16) & 0xffff;
+	RTC->regs->ALRL = value & 0xffff;
+	rtc_exit_config_mode();
+	rtc_wait_finished();
+}

--- a/STM32F1/libraries/RTClock/src/rtc_util.h
+++ b/STM32F1/libraries/RTClock/src/rtc_util.h
@@ -1,0 +1,263 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2011 Visible Assets Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ * @file   rtc.h
+ * @author Rod Gilchrist <rod@visibleassets.com>
+ * @brief  Real Time Clock interface.
+ *
+ */
+
+#ifndef _RTC_UTIL_H
+#define _RTC_UTIL_H
+
+#include <libmaple/libmaple.h>
+#include <libmaple/rcc.h>
+#include <libmaple/nvic.h>
+#include <libmaple/bitband.h>
+#include <libmaple/pwr.h>
+#include <libmaple/bkp.h>
+#include <libmaple/exti.h>
+
+#define EXTI_RTC_ALARM_BIT		17						// the extra exti interrupts (16,17,18,19) should be defined in exti.h (BUG)
+
+//#define RCC_BDCR_RTCSEL_LSI   (0x2 << 8)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct rtc_reg_map {
+	__io uint32 CRH;		/**< Control register high */
+	__io uint32 CRL;		/**< Control register high */
+	__io uint32 PRLH;		/**< Prescaler load register high */
+	__io uint32 PRLL;		/**< Prescaler load register low */
+	__io uint32 DIVH;		/**< Prescaler divider register high */
+	__io uint32 DIVL;		/**< Prescaler divider register low */
+	__io uint32 CNTH;		/**< Counter register high */
+	__io uint32 CNTL;		/**< Counter register low */
+	__io uint32 ALRH;		/**< Alarm register high */
+	__io uint32 ALRL;		/**< Alarm register low */
+} rtc_reg_map;
+		
+/** RTC register map base pointer */
+#define RTC_BASE        ((struct rtc_reg_map*)0x40002800)
+
+/** rtc device type */
+typedef struct rtc_dev {
+	rtc_reg_map *regs;			/**< Register map */
+	voidFuncPtr handlers[];     /**< User IRQ handlers */
+} rtc_dev;
+
+extern rtc_dev *RTC;
+
+
+/*
+ * Register bit definitions
+ */
+	
+/* Control register high (CRH) */
+	
+#define RTC_CRH_OWIE_BIT	2
+#define RTC_CRH_ALRIE_BIT	1
+#define RTC_CRH_SECIE_BIT	0
+
+#define RTC_CRH_OWIE		BIT(RTC_CRH_OWIE_BIT)
+#define RTC_CRH_ALRIE		BIT(RTC_CRH_ALRIE_BIT)
+#define RTC_CRH_SECIE		BIT(RTC_CRH_SECIE_BIT)
+	
+/* Control register low (CRL) */
+
+#define RTC_CRL_RTOFF_BIT	5
+#define RTC_CRL_CNF_BIT		4
+#define RTC_CRL_RSF_BIT		3
+#define RTC_CRL_OWF_BIT		2
+#define RTC_CRL_ALRF_BIT	1
+#define RTC_CRL_SECF_BIT	0
+	
+#define RTC_CRL_RTOFF	BIT(RTC_CRL_RTOFF_BIT)
+#define RTC_CRL_CNF		BIT(RTC_CRL_CNF_BIT)
+#define RTC_CRL_RSF		BIT(RTC_CRL_RSF_BIT)
+#define RTC_CRL_OWF		BIT(RTC_CRL_OWF_BIT)
+#define RTC_CRL_ALRF	BIT(RTC_CRL_ALRF_BIT)
+#define RTC_CRL_SECF	BIT(RTC_CRL_SECF_BIT)
+
+/**
+ * @brief RTC interrupt number.
+ *
+ */
+typedef enum rtc_interrupt_id {
+	RTC_SECONDS_INTERRUPT			= 0,	/**< Counter seconds interrupt */
+	RTC_ALARM_GLOBAL_INTERRUPT		= 1,	/**< RTC alarm global interrupt (i.e. __irq_rtc()) */
+	RTC_OVERFLOW_INTERRUPT			= 2,	/**< Counter overflow interrupt */
+	RTC_ALARM_SPECIFIC_INTERRUPT	= 3		/**< RTC alarm specific interrupt (i.e. __irq_rtcalarm(), wake up from halt/sleep) */
+} rtc_interrupt_id;
+
+void rtc_attach_interrupt(	uint8 interrupt,
+							voidFuncPtr handler);
+void rtc_detach_interrupt(	uint8 interrupt);
+
+/**
+ * @brief RTC clock source.
+ *
+ */
+typedef enum rtc_clk_src {
+	RTCSEL_DEFAULT	= 0,
+	RTCSEL_NONE		= 0x10,
+	RTCSEL_LSE		= 0x11,
+	RTCSEL_LSI		= 0x12,
+	RTCSEL_HSE		= 0x13,
+} rtc_clk_src;
+
+
+void rtc_init(rtc_clk_src src);
+void rtc_attach_interrupt(uint8 interrupt, voidFuncPtr handler);
+void rtc_detach_interrupt(uint8 interrupt);
+uint32 rtc_get_count();
+void rtc_set_count(uint32 value);
+void rtc_set_prescaler_load(uint32 value);
+void rtc_enable_calibration(void);
+void rtc_disable_calibration(void);
+uint32 rtc_get_divider();
+void rtc_set_alarm(uint32 value);
+
+
+/**
+ * @brief Check (wait if necessary) to see the previous write operation has completed.
+ */
+static inline void rtc_wait_finished() {
+	while (*bb_perip(&(RTC->regs)->CRL, RTC_CRL_RTOFF_BIT) == 0);
+}
+
+	/**
+ * @brief Clear the register synchronized flag. The flag is then set by hardware after a write to PRL/DIV or CNT.
+ */
+static inline void rtc_clear_sync() {
+	rtc_wait_finished();
+	*bb_perip(&(RTC->regs)->CRL, RTC_CRL_RSF_BIT) = 0;
+}
+
+/**
+ * @brief Check (wait if necessary) to see RTC registers are synchronized.
+ */
+static inline void rtc_wait_sync() {
+	while (*bb_perip(&(RTC->regs)->CRL, RTC_CRL_RSF_BIT) == 0);
+}
+
+/**
+ * @brief Enter configuration mode.
+ */
+static inline void rtc_enter_config_mode() {
+	rtc_wait_finished();
+	*bb_perip(&(RTC->regs)->CRL, RTC_CRL_CNF_BIT) = 1;
+}
+
+/**
+ * @brief Exit configuration mode.
+ */
+static inline void rtc_exit_config_mode() {
+	rtc_wait_finished();
+	*bb_perip(&(RTC->regs)->CRL, RTC_CRL_CNF_BIT) = 0;
+}
+
+/**
+ * @brief Enable an RTC interrupt.
+ * @param interrupt Interrupt number to enable; this may be any rtc_interrupt_id.
+ * @see rtc_interrupt_id
+ */
+static inline void rtc_enable_irq(uint8 interrupt) {
+	rtc_wait_finished();
+	if (interrupt == RTC_ALARM_SPECIFIC_INTERRUPT) { // Enabling this interrupt allows waking up from deep sleep via WFI.
+		*bb_perip(&EXTI_BASE->IMR, EXTI_RTC_ALARM_BIT) = 1;
+		*bb_perip(&EXTI_BASE->RTSR, EXTI_RTC_ALARM_BIT) = 1;
+	}
+	else *bb_perip(&(RTC->regs)->CRH, interrupt) = 1;
+}
+
+/**
+ * @brief Disable an RTC interrupt.
+ * @param interrupt Interrupt number to disable; this may be any rtc_interrupt_id value.
+ * @see rtc_interrupt_id
+ */
+static inline void rtc_disable_irq(uint8 interrupt) {
+	rtc_wait_finished();
+	if (interrupt == RTC_ALARM_SPECIFIC_INTERRUPT) {
+		*bb_perip(&EXTI_BASE->IMR, EXTI_RTC_ALARM_BIT) = 0;
+		*bb_perip(&EXTI_BASE->RTSR, EXTI_RTC_ALARM_BIT) = 0;
+	}
+	else *bb_perip(&(RTC->regs)->CRH, interrupt) = 0;
+}
+
+/**
+ * @brief Enable an RTC alarm event. Enabling this event allows waking up from deep sleep via WFE.
+ * @see rtc_interrupt_id
+ */
+static inline void rtc_enable_alarm_event() {
+	*bb_perip(&EXTI_BASE->EMR, EXTI_RTC_ALARM_BIT) = 1;
+	*bb_perip(&EXTI_BASE->RTSR, EXTI_RTC_ALARM_BIT) = 1;
+}
+
+/**
+ * @brief Disable the RTC alarm event.
+ * @see rtc_interrupt_id
+ */
+static inline void rtc_disable_alarm_event() {
+	*bb_perip(&EXTI_BASE->EMR, EXTI_RTC_ALARM_BIT) = 0;
+	*bb_perip(&EXTI_BASE->RTSR, EXTI_RTC_ALARM_BIT) = 0;
+}
+
+/**
+ * @brief Test for global interrupt second type.
+ * @see rtc_interrupt_id
+ */
+static inline int rtc_is_second() {
+	return *bb_perip(&(RTC->regs)->CRL, RTC_CRL_SECF_BIT);
+}
+
+/**
+ * @brief Test for global interrupt alarm type.
+ * @see rtc_interrupt_id
+ */
+static inline int rtc_is_alarm() {
+	return *bb_perip(&(RTC->regs)->CRL, RTC_CRL_ALRF_BIT);
+}
+
+/**
+ * @brief Test for global interrupt overflow type.
+ * @see rtc_interrupt_id
+ */
+static inline int rtc_is_overflow() {
+	return *bb_perip(&(RTC->regs)->CRL, RTC_CRL_OWF_BIT);
+}
+
+
+	
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _RTC_H */

--- a/STM32F1/system/libmaple/stm32f1/include/series/rcc.h
+++ b/STM32F1/system/libmaple/stm32f1/include/series/rcc.h
@@ -353,7 +353,7 @@ typedef struct rcc_reg_map {
 #define RCC_BDCR_LSEON_BIT              0
 
 #define RCC_BDCR_BDRST                  (1U << RCC_BDCR_BDRST_BIT)
-#define RCC_BDCR_RTCEN                  (1U << RCC_BDCR_RTC_BIT)
+#define RCC_BDCR_RTCEN                  (0x8 << 10)
 #define RCC_BDCR_RTCSEL                 (0x3 << 8)
 #define RCC_BDCR_RTCSEL_NONE            (0x0 << 8)
 #define RCC_BDCR_RTCSEL_LSE             (0x1 << 8)


### PR DESCRIPTION
Hello. Why not use Adafruit_GFX instead Adafruit_GFX_AS?
i check basic functions as fillscreen, line, rectangle, fillrectangle, fonts - they work fine.
![image](https://user-images.githubusercontent.com/13326299/34199539-afa8f420-e5a0-11e7-8bf1-7298a425db6c.png)
https://youtu.be/g7dh1J98CCc