### PR TITLE
Change floats const to constexpr in STM32ADC

### DIFF
--- a/STM32F1/libraries/STM32ADC/src/STM32ADC.h
+++ b/STM32F1/libraries/STM32ADC/src/STM32ADC.h
@@ -152,7 +152,7 @@ private:
     voidFuncPtr _DMA_int;
     voidFuncPtr _ADC_int;
     voidFuncPtr _AWD_int;
-    static const float _AverageSlope = 4.3; // mV/oC   //4.0 to 4.6
-    static const float _V25 = 1.43; //Volts //1.34 - 1.52
+    static constexpr float _AverageSlope = 4.3; // mV/oC   //4.0 to 4.6
+    static constexpr float _V25 = 1.43; //Volts //1.34 - 1.52
 
 };


### PR DESCRIPTION
Since we are using the C11 flags, we can't use static const with a float, results in error:
/STM32F1/libraries/STM32ADC/src/STM32ADC.h:155:40: error: 'constexpr' needed for in-class initialization of static data member 'const float STM32ADC::_AverageSlope' of non-integral type [-fpermissive]