### PR TITLE
option '#define XTAL16M' for boards with 16MHz-crystal

### DIFF
--- a/STM32F1/variants/generic_stm32f103v/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103v/wirish/boards.cpp
@@ -130,6 +130,12 @@ static void setup_clocks(void) {
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);
 
+#ifdef XTAL16M
+    // 16MHz crystal (HSE)  
+    // in this case we additionally set the Bit 17 (PLLXTPRE=1)  =>  then HSE clock is divided by 2 before PLL entry
+    RCC_BASE->CFGR |= RCC_CFGR_PLLXTPRE;
+#endif
+    
     // Enable the PLL, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_PLL);
     while(!rcc_is_clk_ready(RCC_CLK_PLL))


### PR DESCRIPTION
tested on STM32F103VE only but surely can be used on other STM32F103xC, STM32F103xD, STM32F103xE with the same clock PLL structure.
Therefore it could be used in other "../variant/.." -folders as well, if needed.
 No change to core-files needed.