### PR TITLE
corrected RAM-length = 48kByte for STM32F103VC

### DIFF
--- a/STM32F1/variants/generic_stm32f103v/ld/stm32f103vc.ld
+++ b/STM32F1/variants/generic_stm32f103v/ld/stm32f103vc.ld
@@ -16,7 +16,7 @@
  */
 MEMORY
 {
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
   rom (rx)  : ORIGIN = 0x08000000, LENGTH = 256K
 }
 


### PR DESCRIPTION
regarding: --> https://github.com/rogerclarkmelbourne/Arduino_STM32/issues/420

NOT tested !

the MCU STM32F103VC has 48kByte SRAM (see Datasheet "2.1 Device overview")
and therefore I think this *.ld file has to be corrected.

e.g. called from here - https://github.com/rogerclarkmelbourne/Arduino_STM32/blob/master/STM32F1/boards.txt#L666
  