### PR TITLE
Fixing now() function in RTClock.h

### DIFF
--- a/STM32F1/libraries/RTClock/src/RTClock.h
+++ b/STM32F1/libraries/RTClock/src/RTClock.h
@@ -53,7 +53,7 @@ class RTClock {
 	time_t getTime();
 	void getTime(tm_t & tmm );
 
-    time_t now() { return getTime(); }
+	time_t now() { return getTime(); }
 	void now(tm_t & tmm ) { getTime(tmm); }  // non-standard use of now() function, added for compatibility with previous versions of the library
 
 	uint8_t year(void)    { getTime(tmm); return tmm.year; }

--- a/STM32F1/libraries/RTClock/src/RTClock.h
+++ b/STM32F1/libraries/RTClock/src/RTClock.h
@@ -52,7 +52,9 @@ class RTClock {
 	
 	time_t getTime();
 	void getTime(tm_t & tmm );
-		#define now getTime
+
+    time_t now() { return getTime(); }
+	void now(tm_t & tmm ) { getTime(tmm); }  // non-standard use of now() function, added for compatibility with previous versions of the library
 
 	uint8_t year(void)    { getTime(tmm); return tmm.year; }
 	uint8_t month(void)   { getTime(tmm); return tmm.month; }

--- a/STM32F4/libraries/RTClock/src/RTClock.h
+++ b/STM32F4/libraries/RTClock/src/RTClock.h
@@ -184,7 +184,9 @@ class RTClock {
 	
 	time_t getTime();
 	void getTime(tm_t & tm);
-	#define now getTime
+
+	time_t now() { return getTime(); }
+	void now(tm_t & tmm ) { getTime(tmm); }  // non-standard use of now() function, added for compatibility with previous versions of the library
 
 	uint8_t year(void)    { getTime(tm); return tm.year; }
 	uint8_t month(void)   { getTime(tm); return tm.month; }


### PR DESCRIPTION
It is my first post here so let me first thank you for the library. I like it very much and it helps me with fast development of STM32 apps.

**Now the issue:**

The now() function was defined in RTClock.h using the #define directive. That is
wrong as it prevents using the keyword "now" in other situations.

The minimal error case is:

```
int now;

#include "RTClock.h"

void setup() {
  now = 1;
}

void loop() {}
```

Crashes with:
```
In file included from D:\sketch_feb03a\sketch_feb03a.ino:3:0:

D:\sketch_feb03a\sketch_feb03a.ino: In function 'void setup()':

D:\arduino-1.8.5\hardware\Arduino_STM32\STM32F1\libraries\RTClock\src/RTClock.h:55:25: error: 'getTime' was not declared in this scope

             #define now getTime

                         ^

D:\sketch_feb03a\sketch_feb03a.ino:6:3: note: in expansion of macro 'now'

   now = 1;

   ^

exit status 1
Error compiling for board Generic STM32F103C series.
```
