### PR TITLE
Update timer.h

### DIFF
--- a/STM32F1/system/libmaple/include/libmaple/timer.h
+++ b/STM32F1/system/libmaple/include/libmaple/timer.h
@@ -387,7 +387,7 @@ extern timer_dev timer14;
 #define TIMER_CCMR1_OC1FE_BIT           2
 
 #define TIMER_CCMR1_OC2CE               (1U << TIMER_CCMR1_OC2CE_BIT)
-#define TIMER_CCMR1_OC2M                (0x3 << 12)
+#define TIMER_CCMR1_OC2M                (0x7 << 12)
 #define TIMER_CCMR1_IC2F                (0xF << 12)
 #define TIMER_CCMR1_OC2PE               (1U << TIMER_CCMR1_OC2PE_BIT)
 #define TIMER_CCMR1_OC2FE               (1U << TIMER_CCMR1_OC2FE_BIT)
@@ -398,7 +398,7 @@ extern timer_dev timer14;
 #define TIMER_CCMR1_CC2S_INPUT_TI1      (0x2 << 8)
 #define TIMER_CCMR1_CC2S_INPUT_TRC      (0x3 << 8)
 #define TIMER_CCMR1_OC1CE               (1U << TIMER_CCMR1_OC1CE_BIT)
-#define TIMER_CCMR1_OC1M                (0x3 << 4)
+#define TIMER_CCMR1_OC1M                (0x7 << 4)
 #define TIMER_CCMR1_IC1F                (0xF << 4)
 #define TIMER_CCMR1_OC1PE               (1U << TIMER_CCMR1_OC1PE_BIT)
 #define TIMER_CCMR1_OC1FE               (1U << TIMER_CCMR1_OC1FE_BIT)
@@ -419,7 +419,7 @@ extern timer_dev timer14;
 #define TIMER_CCMR2_OC3FE_BIT           2
 
 #define TIMER_CCMR2_OC4CE               (1U << TIMER_CCMR2_OC4CE_BIT)
-#define TIMER_CCMR2_OC4M                (0x3 << 12)
+#define TIMER_CCMR2_OC4M                (0x7 << 12)
 #define TIMER_CCMR2_IC4F                (0xF << 12)
 #define TIMER_CCMR2_OC4PE               (1U << TIMER_CCMR2_OC4PE_BIT)
 #define TIMER_CCMR2_OC4FE               (1U << TIMER_CCMR2_OC4FE_BIT)
@@ -430,7 +430,7 @@ extern timer_dev timer14;
 #define TIMER_CCMR2_CC4S_INPUT_TI2      (TIMER_CCMR_CCS_INPUT_TI2 << 8)
 #define TIMER_CCMR2_CC4S_INPUT_TRC      (TIMER_CCMR_CCS_INPUT_TRC << 8)
 #define TIMER_CCMR2_OC3CE               (1U << TIMER_CCMR2_OC3CE_BIT)
-#define TIMER_CCMR2_OC3M                (0x3 << 4)
+#define TIMER_CCMR2_OC3M                (0x7 << 4)
 #define TIMER_CCMR2_IC3F                (0xF << 4)
 #define TIMER_CCMR2_OC3PE               (1U << TIMER_CCMR2_OC3PE_BIT)
 #define TIMER_CCMR2_OC3FE               (1U << TIMER_CCMR2_OC3FE_BIT)


### PR DESCRIPTION
corrected mask for OCxM bits in CCMR1/2 registers (see RM0008 rev.16 p. 413)