### PR TITLE
Base Adafruit_GFX_AS on Adafruit_GFX, keeping only the additions in a derived class.

### DIFF
--- a/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.cpp
+++ b/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.cpp
@@ -59,451 +59,15 @@ POSSIBILITY OF SUCH DAMAGE.
  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #endif
 
-Adafruit_GFX::Adafruit_GFX(int16_t w, int16_t h):
-  WIDTH(w), HEIGHT(h)
+Adafruit_GFX_AS::Adafruit_GFX_AS(int16_t w, int16_t h): Adafruit_GFX(w, h)
 {
-  _width    = WIDTH;
-  _height   = HEIGHT;
-  rotation  = 0;
-  cursor_y  = cursor_x    = 0;
-  textsize  = 1;
-  textcolor = textbgcolor = 0xFFFF;
-  wrap      = true;
-}
-
-// Draw a circle outline
-void Adafruit_GFX::drawCircle(int16_t x0, int16_t y0, int16_t r,
-    uint16_t color) {
-  int16_t f = 1 - r;
-  int16_t ddF_x = 1;
-  int16_t ddF_y = -2 * r;
-  int16_t x = 0;
-  int16_t y = r;
-
-  drawPixel(x0  , y0+r, color);
-  drawPixel(x0  , y0-r, color);
-  drawPixel(x0+r, y0  , color);
-  drawPixel(x0-r, y0  , color);
-
-  while (x<y) {
-    if (f >= 0) {
-      y--;
-      ddF_y += 2;
-      f += ddF_y;
-    }
-    x++;
-    ddF_x += 2;
-    f += ddF_x;
-  
-    drawPixel(x0 + x, y0 + y, color);
-    drawPixel(x0 - x, y0 + y, color);
-    drawPixel(x0 + x, y0 - y, color);
-    drawPixel(x0 - x, y0 - y, color);
-    drawPixel(x0 + y, y0 + x, color);
-    drawPixel(x0 - y, y0 + x, color);
-    drawPixel(x0 + y, y0 - x, color);
-    drawPixel(x0 - y, y0 - x, color);
-  }
-}
-
-void Adafruit_GFX::drawCircleHelper( int16_t x0, int16_t y0,
-               int16_t r, uint8_t cornername, uint16_t color) {
-  int16_t f     = 1 - r;
-  int16_t ddF_x = 1;
-  int16_t ddF_y = -2 * r;
-  int16_t x     = 0;
-  int16_t y     = r;
-
-  while (x<y) {
-    if (f >= 0) {
-      y--;
-      ddF_y += 2;
-      f     += ddF_y;
-    }
-    x++;
-    ddF_x += 2;
-    f     += ddF_x;
-    if (cornername & 0x4) {
-      drawPixel(x0 + x, y0 + y, color);
-      drawPixel(x0 + y, y0 + x, color);
-    } 
-    if (cornername & 0x2) {
-      drawPixel(x0 + x, y0 - y, color);
-      drawPixel(x0 + y, y0 - x, color);
-    }
-    if (cornername & 0x8) {
-      drawPixel(x0 - y, y0 + x, color);
-      drawPixel(x0 - x, y0 + y, color);
-    }
-    if (cornername & 0x1) {
-      drawPixel(x0 - y, y0 - x, color);
-      drawPixel(x0 - x, y0 - y, color);
-    }
-  }
-}
-
-void Adafruit_GFX::fillCircle(int16_t x0, int16_t y0, int16_t r,
-			      uint16_t color) {
-  drawFastVLine(x0, y0-r, 2*r+1, color);
-  fillCircleHelper(x0, y0, r, 3, 0, color);
-}
-
-// Used to do circles and roundrects
-void Adafruit_GFX::fillCircleHelper(int16_t x0, int16_t y0, int16_t r,
-    uint8_t cornername, int16_t delta, uint16_t color) {
-
-  int16_t f     = 1 - r;
-  int16_t ddF_x = 1;
-  int16_t ddF_y = -2 * r;
-  int16_t x     = 0;
-  int16_t y     = r;
-
-  while (x<y) {
-    if (f >= 0) {
-      y--;
-      ddF_y += 2;
-      f     += ddF_y;
-    }
-    x++;
-    ddF_x += 2;
-    f     += ddF_x;
-
-    if (cornername & 0x1) {
-      drawFastVLine(x0+x, y0-y, 2*y+1+delta, color);
-      drawFastVLine(x0+y, y0-x, 2*x+1+delta, color);
-    }
-    if (cornername & 0x2) {
-      drawFastVLine(x0-x, y0-y, 2*y+1+delta, color);
-      drawFastVLine(x0-y, y0-x, 2*x+1+delta, color);
-    }
-  }
-}
-
-// Bresenham's algorithm - thx wikpedia
-void Adafruit_GFX::drawLine(int16_t x0, int16_t y0,
-			    int16_t x1, int16_t y1,
-			    uint16_t color) {
-  int16_t steep = abs(y1 - y0) > abs(x1 - x0);
-  if (steep) {
-    swap(x0, y0);
-    swap(x1, y1);
-  }
-
-  if (x0 > x1) {
-    swap(x0, x1);
-    swap(y0, y1);
-  }
-
-  int16_t dx, dy;
-  dx = x1 - x0;
-  dy = abs(y1 - y0);
-
-  int16_t err = dx / 2;
-  int16_t ystep;
-
-  if (y0 < y1) {
-    ystep = 1;
-  } else {
-    ystep = -1;
-  }
-
-  for (; x0<=x1; x0++) {
-    if (steep) {
-      drawPixel(y0, x0, color);
-    } else {
-      drawPixel(x0, y0, color);
-    }
-    err -= dy;
-    if (err < 0) {
-      y0 += ystep;
-      err += dx;
-    }
-  }
-}
-
-// Draw a rectangle
-void Adafruit_GFX::drawRect(int16_t x, int16_t y,
-			    int16_t w, int16_t h,
-			    uint16_t color) {
-  drawFastHLine(x, y, w, color);
-  drawFastHLine(x, y+h-1, w, color);
-  drawFastVLine(x, y, h, color);
-  drawFastVLine(x+w-1, y, h, color);
-}
-
-void Adafruit_GFX::drawFastVLine(int16_t x, int16_t y,
-				 int16_t h, uint16_t color) {
-  // Update in subclasses if desired!
-  drawLine(x, y, x, y+h-1, color);
-}
-
-void Adafruit_GFX::drawFastHLine(int16_t x, int16_t y,
-				 int16_t w, uint16_t color) {
-  // Update in subclasses if desired!
-  drawLine(x, y, x+w-1, y, color);
-}
-
-void Adafruit_GFX::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
-			    uint16_t color) {
-  // Update in subclasses if desired!
-  for (int16_t i=x; i<x+w; i++) {
-    drawFastVLine(i, y, h, color);
-  }
-}
-
-void Adafruit_GFX::fillScreen(uint16_t color) {
-  fillRect(0, 0, _width, _height, color);
-}
-
-// Draw a rounded rectangle
-void Adafruit_GFX::drawRoundRect(int16_t x, int16_t y, int16_t w,
-  int16_t h, int16_t r, uint16_t color) {
-  // smarter version
-  drawFastHLine(x+r  , y    , w-2*r, color); // Top
-  drawFastHLine(x+r  , y+h-1, w-2*r, color); // Bottom
-  drawFastVLine(x    , y+r  , h-2*r, color); // Left
-  drawFastVLine(x+w-1, y+r  , h-2*r, color); // Right
-  // draw four corners
-  drawCircleHelper(x+r    , y+r    , r, 1, color);
-  drawCircleHelper(x+w-r-1, y+r    , r, 2, color);
-  drawCircleHelper(x+w-r-1, y+h-r-1, r, 4, color);
-  drawCircleHelper(x+r    , y+h-r-1, r, 8, color);
-}
-
-// Fill a rounded rectangle
-void Adafruit_GFX::fillRoundRect(int16_t x, int16_t y, int16_t w,
-				 int16_t h, int16_t r, uint16_t color) {
-  // smarter version
-  fillRect(x+r, y, w-2*r, h, color);
-
-  // draw four corners
-  fillCircleHelper(x+w-r-1, y+r, r, 1, h-2*r-1, color);
-  fillCircleHelper(x+r    , y+r, r, 2, h-2*r-1, color);
-}
-
-// Draw a triangle
-void Adafruit_GFX::drawTriangle(int16_t x0, int16_t y0,
-				int16_t x1, int16_t y1,
-				int16_t x2, int16_t y2, uint16_t color) {
-  drawLine(x0, y0, x1, y1, color);
-  drawLine(x1, y1, x2, y2, color);
-  drawLine(x2, y2, x0, y0, color);
-}
-
-// Fill a triangle
-void Adafruit_GFX::fillTriangle ( int16_t x0, int16_t y0,
-				  int16_t x1, int16_t y1,
-				  int16_t x2, int16_t y2, uint16_t color) {
-
-  int16_t a, b, y, last;
-
-  // Sort coordinates by Y order (y2 >= y1 >= y0)
-  if (y0 > y1) {
-    swap(y0, y1); swap(x0, x1);
-  }
-  if (y1 > y2) {
-    swap(y2, y1); swap(x2, x1);
-  }
-  if (y0 > y1) {
-    swap(y0, y1); swap(x0, x1);
-  }
-
-  if(y0 == y2) { // Handle awkward all-on-same-line case as its own thing
-    a = b = x0;
-    if(x1 < a)      a = x1;
-    else if(x1 > b) b = x1;
-    if(x2 < a)      a = x2;
-    else if(x2 > b) b = x2;
-    drawFastHLine(a, y0, b-a+1, color);
-    return;
-  }
-
-  int16_t
-    dx01 = x1 - x0,
-    dy01 = y1 - y0,
-    dx02 = x2 - x0,
-    dy02 = y2 - y0,
-    dx12 = x2 - x1,
-    dy12 = y2 - y1,
-    sa   = 0,
-    sb   = 0;
-
-  // For upper part of triangle, find scanline crossings for segments
-  // 0-1 and 0-2.  If y1=y2 (flat-bottomed triangle), the scanline y1
-  // is included here (and second loop will be skipped, avoiding a /0
-  // error there), otherwise scanline y1 is skipped here and handled
-  // in the second loop...which also avoids a /0 error here if y0=y1
-  // (flat-topped triangle).
-  if(y1 == y2) last = y1;   // Include y1 scanline
-  else         last = y1-1; // Skip it
-
-  for(y=y0; y<=last; y++) {
-    a   = x0 + sa / dy01;
-    b   = x0 + sb / dy02;
-    sa += dx01;
-    sb += dx02;
-    /* longhand:
-    a = x0 + (x1 - x0) * (y - y0) / (y1 - y0);
-    b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
-    */
-    if(a > b) swap(a,b);
-    drawFastHLine(a, y, b-a+1, color);
-  }
-
-  // For lower part of triangle, find scanline crossings for segments
-  // 0-2 and 1-2.  This loop is skipped if y1=y2.
-  sa = dx12 * (y - y1);
-  sb = dx02 * (y - y0);
-  for(; y<=y2; y++) {
-    a   = x1 + sa / dy12;
-    b   = x0 + sb / dy02;
-    sa += dx12;
-    sb += dx02;
-    /* longhand:
-    a = x1 + (x2 - x1) * (y - y1) / (y2 - y1);
-    b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
-    */
-    if(a > b) swap(a,b);
-    drawFastHLine(a, y, b-a+1, color);
-  }
-}
-
-void Adafruit_GFX::drawBitmap(int16_t x, int16_t y,
-			      const uint8_t *bitmap, int16_t w, int16_t h,
-			      uint16_t color) {
-
-  int16_t i, j, byteWidth = (w + 7) / 8;
-
-  for(j=0; j<h; j++) {
-    for(i=0; i<w; i++ ) {
-      if(pgm_read_byte(bitmap + j * byteWidth + i / 8) & (128 >> (i & 7))) {
-	drawPixel(x+i, y+j, color);
-      }
-    }
-  }
-}
-
-//#if ARDUINO >= 100
-size_t Adafruit_GFX::write(uint8_t c) {
-//#else
-//void Adafruit_GFX::write(uint8_t c) {
-//#endif
-  if (c == '\n') {
-    cursor_y += textsize*8;
-    cursor_x  = 0;
-  } else if (c == '\r') {
-    // skip em
-  } else {
-    drawChar(cursor_x, cursor_y, c, textcolor, textbgcolor, textsize);
-    cursor_x += textsize*6;
-    if (wrap && (cursor_x > (_width - textsize*6))) {
-      cursor_y += textsize*8;
-      cursor_x = 0;
-    }
-  }
-//#if ARDUINO >= 100
-  return 1;
-//#endif
-}
-
-// Draw a character
-void Adafruit_GFX::drawChar(int16_t x, int16_t y, unsigned char c,
-			    uint16_t color, uint16_t bg, uint8_t size) {
-#ifdef LOAD_GLCD
-  if((x >= _width)            || // Clip right
-     (y >= _height)           || // Clip bottom
-     ((x + 6 * size - 1) < 0) || // Clip left
-     ((y + 8 * size - 1) < 0))   // Clip top
-    return;
-
-  for (int8_t i=0; i<6; i++ ) {
-    uint8_t line;
-    if (i == 5) 
-      line = 0x0;
-    else 
-      line = pgm_read_byte(font+(c*5)+i);
-    for (int8_t j = 0; j<8; j++) {
-      if (line & 0x1) {
-        if (size == 1) // default size
-          drawPixel(x+i, y+j, color);
-        else {  // big size
-          fillRect(x+(i*size), y+(j*size), size, size, color);
-        } 
-      } else if (bg != color) {
-        if (size == 1) // default size
-          drawPixel(x+i, y+j, bg);
-        else {  // big size
-          fillRect(x+i*size, y+j*size, size, size, bg);
-        }
-      }
-      line >>= 1;
-    }
-  }
-#endif
-}
-
-void Adafruit_GFX::setCursor(int16_t x, int16_t y) {
-  cursor_x = x;
-  cursor_y = y;
-}
-
-void Adafruit_GFX::setTextSize(uint8_t s) {
-  textsize = (s > 0) ? s : 1;
-}
-
-void Adafruit_GFX::setTextColor(uint16_t c) {
-  // For 'transparent' background, we'll set the bg 
-  // to the same as fg instead of using a flag
-  textcolor = textbgcolor = c;
-}
-
-void Adafruit_GFX::setTextColor(uint16_t c, uint16_t b) {
-  textcolor   = c;
-  textbgcolor = b; 
-}
-
-void Adafruit_GFX::setTextWrap(boolean w) {
-  wrap = w;
-}
-
-uint8_t Adafruit_GFX::getRotation(void) {
-  return rotation;
-}
-
-void Adafruit_GFX::setRotation(uint8_t x) {
-  rotation = (x & 3);
-  switch(rotation) {
-   case 0:
-   case 2:
-    _width  = WIDTH;
-    _height = HEIGHT;
-    break;
-   case 1:
-   case 3:
-    _width  = HEIGHT;
-    _height = WIDTH;
-    break;
-  }
-}
-
-// Return the size of the display (per current rotation)
-int16_t Adafruit_GFX::width(void) {
-  return _width;
-}
- 
-int16_t Adafruit_GFX::height(void) {
-  return _height;
-}
-
-void Adafruit_GFX::invertDisplay(boolean i) {
-  // Do nothing, must be subclassed if supported
 }
 
 /***************************************************************************************
 ** Function name:           drawUnicode
 ** Descriptions:            draw a unicode
 ***************************************************************************************/
-int16_t Adafruit_GFX::drawUnicode(uint16_t uniCode, int16_t x, int16_t y, int16_t size)
+int16_t Adafruit_GFX_AS::drawUnicode(uint16_t uniCode, int16_t x, int16_t y, int16_t size)
 {
     
    if (size) uniCode -= 32;
@@ -615,7 +179,7 @@ return (width+gap)*textsize;        // x +
 ** Function name:           drawNumber unsigned with size
 ** Descriptions:            drawNumber
 ***************************************************************************************/
-int16_t Adafruit_GFX::drawNumber(long long_num,int16_t poX, int16_t poY, int16_t size)
+int16_t Adafruit_GFX_AS::drawNumber(long long_num,int16_t poX, int16_t poY, int16_t size)
 {
     char tmp[10];
     if (long_num < 0) sprintf(tmp, "%li", long_num);
@@ -627,7 +191,7 @@ int16_t Adafruit_GFX::drawNumber(long long_num,int16_t poX, int16_t poY, int16_t
 ** Function name:           drawChar
 ** Descriptions:            draw char
 ***************************************************************************************/
-int16_t Adafruit_GFX::drawChar(char c, int16_t x, int16_t y, int16_t size)
+int16_t Adafruit_GFX_AS::drawChar(char c, int16_t x, int16_t y, int16_t size)
 {
     return drawUnicode(c, x, y, size);
 }
@@ -636,7 +200,7 @@ int16_t Adafruit_GFX::drawChar(char c, int16_t x, int16_t y, int16_t size)
 ** Function name:           drawString
 ** Descriptions:            draw string
 ***************************************************************************************/
-int16_t Adafruit_GFX::drawString(char *string, int16_t poX, int16_t poY, int16_t size)
+int16_t Adafruit_GFX_AS::drawString(char *string, int16_t poX, int16_t poY, int16_t size)
 {
     int16_t sumX = 0;
 
@@ -654,7 +218,7 @@ int16_t Adafruit_GFX::drawString(char *string, int16_t poX, int16_t poY, int16_t
 ** Function name:           drawCentreString
 ** Descriptions:            draw string across centre
 ***************************************************************************************/
-int16_t Adafruit_GFX::drawCentreString(char *string, int16_t dX, int16_t poY, int16_t size)
+int16_t Adafruit_GFX_AS::drawCentreString(char *string, int16_t dX, int16_t poY, int16_t size)
 {
     int16_t sumX = 0;
     int16_t len = 0;
@@ -703,7 +267,7 @@ int16_t Adafruit_GFX::drawCentreString(char *string, int16_t dX, int16_t poY, in
 ** Function name:           drawRightString
 ** Descriptions:            draw string right justified
 ***************************************************************************************/
-int16_t Adafruit_GFX::drawRightString(char *string, int16_t dX, int16_t poY, int16_t size)
+int16_t Adafruit_GFX_AS::drawRightString(char *string, int16_t dX, int16_t poY, int16_t size)
 {
     int16_t sumX = 0;
     int16_t len = 0;
@@ -754,7 +318,7 @@ int16_t Adafruit_GFX::drawRightString(char *string, int16_t dX, int16_t poY, int
 ** Function name:           drawFloat
 ** Descriptions:            drawFloat
 ***************************************************************************************/
-int16_t Adafruit_GFX::drawFloat(float floatNumber, int16_t decimal, int16_t poX, int16_t poY, int16_t size)
+int16_t Adafruit_GFX_AS::drawFloat(float floatNumber, int16_t decimal, int16_t poX, int16_t poY, int16_t size)
 {
     unsigned long temp=0;
     float decy=0.0;

--- a/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.h
+++ b/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.h
@@ -1,64 +1,20 @@
-#ifndef _ADAFRUIT_GFX_H
-#define _ADAFRUIT_GFX_H
+#ifndef _ADAFRUIT_GFX_AS_H
+#define _ADAFRUIT_GFX_AS_H
 
 #include "Load_fonts.h"
 
-#if ARDUINO >= 100
- #include "Arduino.h"
- #include "Print.h"
-#else
- #include "WProgram.h"
-#endif
+#include <Adafruit_GFX.h>
 
 #define swap(a, b) { int16_t t = a; a = b; b = t; }
 
-class Adafruit_GFX : public Print {
-
- public:
-
-  Adafruit_GFX(int16_t w, int16_t h); // Constructor
-
-  // This MUST be defined by the subclass:
-  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
-
-  // These MAY be overridden by the subclass to provide device-specific
-  // optimized code.  Otherwise 'generic' versions are used.
-  virtual void
-    drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color),
-    drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-    drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-    drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-    fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-    fillScreen(uint16_t color),
-    invertDisplay(boolean i);
-
-  // These exist only with Adafruit_GFX (no subclass overrides)
-  void
-    drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      uint16_t color),
-    fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      int16_t delta, uint16_t color),
-    drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color),
-    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
-      uint16_t bg, uint8_t size),
-    setCursor(int16_t x, int16_t y),
-    setTextColor(uint16_t c),
-    setTextColor(uint16_t c, uint16_t bg),
-    setTextSize(uint8_t s),
-    setTextWrap(boolean w),
-    setRotation(uint8_t r);
-
+/** This class provides a few extensions to Adafruit_GFX, mostly for compatibility with
+ *  existing code. Note that the fonts ("size" parameter) are not the same ones use as the
+ *  ones provided by Adafruit_GFX. Using any of the functions defined in this class will
+ *  therefore pull additional font tables into flash. If that is an issue, try to stick
+ *  to the base class, or trim down the fonts loaded in Load_fonts.h . */
+class Adafruit_GFX_AS : public Adafruit_GFX {
+public:
+    Adafruit_GFX_AS(int16_t w, int16_t h); // Constructor
     int16_t drawUnicode(uint16_t uniCode, int16_t x, int16_t y, int16_t size);
     int16_t drawNumber(long long_num,int16_t poX, int16_t poY, int16_t size);
     int16_t drawChar(char c, int16_t x, int16_t y, int16_t size);
@@ -66,32 +22,6 @@ class Adafruit_GFX : public Print {
     int16_t drawCentreString(char *string, int16_t dX, int16_t poY, int16_t size);
     int16_t drawRightString(char *string, int16_t dX, int16_t poY, int16_t size);
     int16_t drawFloat(float floatNumber,int16_t decimal,int16_t poX, int16_t poY, int16_t size);
-
-#if ARDUINO >= 100
-  virtual size_t write(uint8_t);
-#else
-  virtual void   write(uint8_t);
-#endif
-
-  int16_t
-    height(void),
-    width(void);
-
-  uint8_t getRotation(void);
-
- protected:
-  const int16_t
-    WIDTH, HEIGHT;   // This is the 'raw' display w/h - never changes
-  int16_t
-    _width, _height, // Display w/h as modified by current rotation
-    cursor_x, cursor_y;
-  uint16_t
-    textcolor, textbgcolor;
-  uint8_t
-    textsize,
-    rotation;
-  boolean
-    wrap; // If set, 'wrap' text at right edge of display
 };
 
-#endif // _ADAFRUIT_GFX_H
+#endif // _ADAFRUIT_GFX_AS_H

--- a/STM32F1/libraries/Adafruit_GFX_AS/README.txt
+++ b/STM32F1/libraries/Adafruit_GFX_AS/README.txt
@@ -1,14 +1,22 @@
-This library has minor modifications to support STM32.
-It also was modified to include additional fonts.
+This library adds a few font-related functions on top of the Adafruit_GFX library (which you need to install, separately).
 
-This is the core graphics library for all our displays, providing a common set of graphics primitives (points, lines, circles, etc.).  It needs to be paired with a hardware-specific library for each display device we carry (to handle the lower-level functions).
+Historically, Adafruit_GFX_AS started as a fork of Adafruit_GFX. Most importantly, it added support for using additional fonts,
+before similar functionality became available in Adafruit_GFX.
+
+Today, the main point of this library is to continue supporting projects that have made use of the functions added in Adafruit_GFX_AS,
+while also being fully compatible with Adafruit_GFX (which is used as the base class). It is not recommended to use the functions
+provided by the Adafruit_GFX_AS class in newly developed code.
+
+To use this library with a driver that is not based on Adafruit_GFX_AS, all you will have to do is to replace "Adafrui_GFX" with "Adafruit_GFX_AS"
+in your driver code. This will usually be three places: The #include-directive, the base-class declaration, and the call to the base-contstructor.
 
 Adafruit invests time and resources providing this open source code, please support Adafruit and open-source hardware by purchasing products from Adafruit!
 
-Written by Limor Fried/Ladyada for Adafruit Industries.
+Adafruit_GFX Written by Limor Fried/Ladyada for Adafruit Industries.
+Adafruit_GFX_AS funtions added by "Bodmer"(?)
 BSD license, check license.txt for more information.
 All text above must be included in any redistribution.
 
-To download, click the DOWNLOAD ZIP button, uncompress and rename the uncompressed folder Adafruit_GFX. Confirm that the Adafruit_GFX folder contains Adafruit_GFX.cpp and Adafruit_GFX.h
+To download, click the DOWNLOAD ZIP button, uncompress and rename the uncompressed folder Adafruit_GFX_AS. Confirm that the Adafruit_GFX_AS folder contains Adafruit_GFX_AS.cpp and Adafruit_GFX_AS.h
 
-Place the Adafruit_GFX library folder your <arduinosketchfolder>/Libraries/ folder. You may need to create the Libraries subfolder if its your first library. Restart the IDE.
+Place the Adafruit_GFX_AS library folder your <arduinosketchfolder>/Libraries/ folder. You may need to create the Libraries subfolder if its your first library. Restart the IDE.

--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
@@ -8,7 +8,7 @@ Includes DMA transfers on DMA1 CH2 and CH3.
 
 // Constructor when using hardware SPI.  Faster, but must use SPI pins
 // specific to each board type (e.g. 11,13 for Uno, 51,52 for Mega, etc.)
-Adafruit_ILI9341_STM::Adafruit_ILI9341_STM(int8_t cs, int8_t dc, int8_t rst) : Adafruit_GFX(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT)
+Adafruit_ILI9341_STM::Adafruit_ILI9341_STM(int8_t cs, int8_t dc, int8_t rst) : Adafruit_GFX_AS(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT)
 {
   _cs   = cs;
   _dc   = dc;

--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
@@ -95,7 +95,7 @@ This library has been modified for the Maple Mini
 #define ILI9341_GREENYELLOW 0xAFE5      /* 173, 255,  47 */
 #define ILI9341_PINK        0xF81F
 
-class Adafruit_ILI9341_STM : public Adafruit_GFX {
+class Adafruit_ILI9341_STM : public Adafruit_GFX_AS {
 
  public:
 


### PR DESCRIPTION
The point of this is to make drivers based on Adafruit_GFX_AS compatible with Adafruit_GFX,
without breaking existing code written for Adafruit_GFX_AS.

See also http://stm32duino.com/viewtopic.php?f=9&t=3352