### PR TITLE
Update i2c.c

### DIFF
--- a/STM32F1/cores/maple/libmaple/i2c.c
+++ b/STM32F1/cores/maple/libmaple/i2c.c
@@ -324,7 +324,7 @@ void _i2c_irq_handler(i2c_dev *dev) {
     /*
      * EV6: Slave address sent
      */
-    if (sr1 & I2C_SR1_ADDR) {
+    if (sr1 & (I2C_SR1_ADDR|I2C_SR1_ADD10)) {
         /*
          * Special case event EV6_1 for master receiver.
          * Generate NACK and restart/stop condition after ADDR


### PR DESCRIPTION
fix for unrecognized devices having ID 0x7..

I tested in my case (ID=0x78) and it works as expected.
Very possible that will fix other unrecognized devices as well, see http://www.stm32duino.com/viewtopic.php?f=14&t=3259&start=10#p41749.
