### PR TITLE
Update to fix FSMC inclusion in Rx devices

### DIFF
--- a/STM32F1/system/libmaple/stm32f1/include/series/stm32.h
+++ b/STM32F1/system/libmaple/stm32f1/include/series/stm32.h
@@ -187,6 +187,8 @@ extern "C" {
 #       define STM32_TIMER_MASK         0x1FE /* TIMER1--TIMER8 */
 #       if STM32_NR_GPIO_PORTS > 4
 #           define STM32_HAVE_FSMC      1
+#       else
+#           define STM32_HAVE_FSMC      0
 #       endif
 #       define STM32_HAVE_DAC           1
 #    elif defined(STM32_XL_DENSITY)
@@ -194,6 +196,8 @@ extern "C" {
 #       define STM32_TIMER_MASK         0x7FFE /* TIMER1--TIMER14 */
 #       if STM32_NR_GPIO_PORTS > 4
 #           define STM32_HAVE_FSMC      1
+#       else
+#           define STM32_HAVE_FSMC      0
 #       endif
 #       define STM32_HAVE_DAC           1
 #    endif

--- a/STM32F1/system/libmaple/stm32f1/include/series/stm32.h
+++ b/STM32F1/system/libmaple/stm32f1/include/series/stm32.h
@@ -185,12 +185,16 @@ extern "C" {
 #    elif defined(STM32_HIGH_DENSITY)
 #       define STM32_NR_INTERRUPTS      60
 #       define STM32_TIMER_MASK         0x1FE /* TIMER1--TIMER8 */
-#       define STM32_HAVE_FSMC          1
+#       if STM32_NR_GPIO_PORTS > 4
+#           define STM32_HAVE_FSMC      1
+#       endif
 #       define STM32_HAVE_DAC           1
 #    elif defined(STM32_XL_DENSITY)
 #       define STM32_NR_INTERRUPTS      60
 #       define STM32_TIMER_MASK         0x7FFE /* TIMER1--TIMER14 */
-#       define STM32_HAVE_FSMC          1
+#       if STM32_NR_GPIO_PORTS > 4
+#           define STM32_HAVE_FSMC      1
+#       endif
 #       define STM32_HAVE_DAC           1
 #    endif
 


### PR DESCRIPTION
The FSMC is only available in high density and XL density devices with more than 4 ports.
Basically excluded in the RC/D/E/F/G models, since they dont have enough pins.
Page 11 in the Datasheet references this. The table shows what is present, and shows the FSMC is NOT present in Rx MCUs:
http://www.st.com/content/ccc/resource/technical/document/datasheet/59/f6/fa/84/20/4e/4c/59/CD00191185.pdf/files/CD00191185.pdf/jcr:content/translations/en.CD00191185.pdf

Recent changes to other files highlight this issue during compilation time. The issue was already there, but GPIO E and GPIO F were declared and defined, while they don't actually exist in Rx MCUs, so FSMC was being included for those MCU even though they don't actually have an FSMC device, or at least no external ports to use it. 
With the recent changes GPIO E and F and correctly excluded from the build, but since FSMC was still included and needs GPIO E and F, it was failing to compile. I.e.:
C:/Users/Victor/Documents/Arduino/Hardware/Arduino_STM32/STM32F1/cores/maple/libmaple/fsmc_f1.c:51:19: error: 'GPIOE' undeclared (first use in this function)

Since the FSMC is not available (I suspect the silicon is there, but there is no IO pins to use it), the correct solution is to include FSMC only when using an MCU with more than 4 GPIO ports, which is what matches the datasheet.