### PR TITLE
F1 : Update Wire.cpp

### DIFF
--- a/STM32F1/libraries/Wire/Wire.cpp
+++ b/STM32F1/libraries/Wire/Wire.cpp
@@ -50,7 +50,7 @@ uint8 TwoWire::process(uint8 stop) {
             res = EOTHER;
         }
         i2c_disable(sel_hard);
-        i2c_master_enable(sel_hard, (I2C_BUS_RESET | dev_flags));
+        i2c_master_enable(sel_hard, dev_flags);
     }
     return res;
 }


### PR DESCRIPTION
bugfix hw I2C unrecognized addresses 0x76, 0x77.

As discussed in http://www.stm32duino.com/viewtopic.php?f=14&t=3259&p=44458#p44392.
Tested with i2c scanner sketch.