### PR TITLE
Fixed missing return value.

### DIFF
--- a/STM32F1/libraries/Wire/utility/WireBase.cpp
+++ b/STM32F1/libraries/Wire/utility/WireBase.cpp
@@ -71,7 +71,7 @@ uint8 WireBase::endTransmission(bool stop) {
 }
 
 uint8 WireBase::endTransmission(){
-    endTransmission(true);
+    return endTransmission(true);
 }
 
 //TODO: Add the ability to queue messages (adding a boolean to end of function


### PR DESCRIPTION
Overloaded method was not returning the result.