### PR TITLE
Added preprocessor symbol USE_HSI_CLOCK for running with HSI clocking

### DIFF
--- a/STM32F1/variants/generic_gd32f103c/wirish/boards.cpp
+++ b/STM32F1/variants/generic_gd32f103c/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_gd32f103c/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_gd32f103c/wirish/boards_setup.cpp
@@ -46,6 +46,7 @@
 // Additionally the GD32 has a 4 USB PLL divider settings, rather than the 2 settings in the STM32, which allow it to operate on frequencies of 48,72,96 and 120Mhz and still have USB functioning
 
 #ifndef BOARD_RCC_PLLMUL
+#if !USE_HSI_CLOCK
 #if F_CPU==120000000
 	#define BOARD_RCC_PLLMUL RCC_PLLMUL_10
 #elif F_CPU==96000000
@@ -53,14 +54,20 @@
 #elif F_CPU==72000000
 	#define BOARD_RCC_PLLMUL RCC_PLLMUL_6	
 #endif
-
+#else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+#endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 

--- a/STM32F1/variants/generic_stm32f103c/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103c/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
@@ -48,6 +48,7 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+  #if !USE_HSI_CLOCK
 	#if F_CPU==128000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
 	#elif F_CPU==72000000
@@ -57,13 +58,20 @@
 	#elif F_CPU==16000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
+  #else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+  #endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 

--- a/STM32F1/variants/generic_stm32f103r/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103r/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_stm32f103r/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103r/wirish/boards_setup.cpp
@@ -48,6 +48,7 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+  #if !USE_HSI_CLOCK
 	#if F_CPU==128000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
 	#elif F_CPU==72000000
@@ -57,13 +58,20 @@
 	#elif F_CPU==16000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
+  #else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+  #endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 

--- a/STM32F1/variants/generic_stm32f103r8/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103r8/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_stm32f103r8/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103r8/wirish/boards_setup.cpp
@@ -48,6 +48,7 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+  #if !USE_HSI_CLOCK
 	#if F_CPU==128000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
 	#elif F_CPU==72000000
@@ -57,13 +58,20 @@
 	#elif F_CPU==16000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
+  #else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+  #endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 

--- a/STM32F1/variants/generic_stm32f103t/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103t/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_stm32f103t/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103t/wirish/boards_setup.cpp
@@ -48,6 +48,7 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+  #if !USE_HSI_CLOCK
 	#if F_CPU==128000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
 	#elif F_CPU==72000000
@@ -57,13 +58,20 @@
 	#elif F_CPU==16000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
+  #else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+  #endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 

--- a/STM32F1/variants/generic_stm32f103v/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103v/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_stm32f103v/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103v/wirish/boards_setup.cpp
@@ -48,6 +48,7 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+  #if !USE_HSI_CLOCK
 	#if F_CPU==128000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
 	#elif F_CPU==72000000
@@ -57,13 +58,20 @@
 	#elif F_CPU==16000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
+  #else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+  #endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 

--- a/STM32F1/variants/generic_stm32f103vb/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103vb/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_stm32f103vb/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103vb/wirish/boards_setup.cpp
@@ -48,6 +48,7 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+  #if !USE_HSI_CLOCK
 	#if F_CPU==128000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
 	#elif F_CPU==72000000
@@ -57,13 +58,20 @@
 	#elif F_CPU==16000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
+  #else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+  #endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 

--- a/STM32F1/variants/generic_stm32f103z/wirish/boards.cpp
+++ b/STM32F1/variants/generic_stm32f103z/wirish/boards.cpp
@@ -120,12 +120,12 @@ static void setup_clocks(void) {
     // Clear clock readiness interrupt flags and turn off clock
     // readiness interrupts.
     RCC_BASE->CIR = 0x00000000;
-
+#if !USE_HSI_CLOCK
     // Enable HSE, and wait until it's ready.
     rcc_turn_on_clk(RCC_CLK_HSE);
     while (!rcc_is_clk_ready(RCC_CLK_HSE))
         ;
-
+#endif
     // Configure AHBx, APBx, etc. prescalers and the main PLL.
     wirish::priv::board_setup_clock_prescalers();
     rcc_configure_pll(&wirish::priv::w_board_pll_cfg);

--- a/STM32F1/variants/generic_stm32f103z/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103z/wirish/boards_setup.cpp
@@ -48,6 +48,7 @@
 // works for F103 performance line MCUs, which is all that LeafLabs
 // currently officially supports).
 #ifndef BOARD_RCC_PLLMUL
+  #if !USE_HSI_CLOCK
 	#if F_CPU==128000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
 	#elif F_CPU==72000000
@@ -57,13 +58,20 @@
 	#elif F_CPU==16000000
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
+  #else
+	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+  #endif
 #endif
 
 namespace wirish {
     namespace priv {
 
         static stm32f1_rcc_pll_data pll_data = {BOARD_RCC_PLLMUL};
+#if !USE_HSI_CLOCK
         __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSE, &pll_data};
+#else
+        __weak rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+#endif
         __weak adc_prescaler w_adc_pre = ADC_PRE_PCLK2_DIV_6;
         __weak adc_smp_rate w_adc_smp = ADC_SMPR_55_5;
 


### PR DESCRIPTION
This change is done for generic variants only. By default, HSE clocking scheme is used, as before this change.

Signed-off-by: Alexandr Zarubkin <me21@yandex.ru>