### PR TITLE
Fix to delayMicroseconds(0) bug

### DIFF
--- a/STM32F1/system/libmaple/include/libmaple/delay.h
+++ b/STM32F1/system/libmaple/include/libmaple/delay.h
@@ -46,6 +46,7 @@ extern "C" {
  * @param us Number of microseconds to delay.
  */
 static inline void delay_us(uint32 us) {
+    if(!us) return;
     us *= STM32_DELAY_US_MULT;
 
     /* fudge for function call overhead  */


### PR DESCRIPTION
Ciao @rogerclarkmelbourne here is the fix as you requested https://github.com/rogerclarkmelbourne/Arduino_STM32/issues/531
