### PR TITLE
STM32F407 BKPSRAM Boundary address fix

### DIFF
--- a/STM32F4/cores/maple/libmaple/bkp.h
+++ b/STM32F4/cores/maple/libmaple/bkp.h
@@ -99,7 +99,7 @@ typedef struct bkp_reg_map {
 } bkp_reg_map;
 
 /** Backup peripheral register map base pointer. */
-#define BKP_BASE                        ((struct bkp_reg_map*)0x40006C00)
+#define BKP_BASE                        ((struct bkp_reg_map*)0x40024000)
 
 /** Backup peripheral device type. */
 typedef struct bkp_dev {


### PR DESCRIPTION
Fix for the Backup RAM.

Example code:

...
#include <libmaple/bkp.h>
...

bkp_init();
bkp_enable_writes();
bkp_write(1, 0x1234); //Writes the value 0x1234 at Backup RAM address 1
bkp_disable_writes();
Serial.print(bkp_read(1)); //Print the value of the Backup RAM address 1
...