### PR TITLE
F1: fix wrong delay timing

### DIFF
--- a/STM32F1/cores/maple/wirish_time.cpp
+++ b/STM32F1/cores/maple/wirish_time.cpp
@@ -34,13 +34,18 @@
 #include <libmaple/delay.h>
 #include "Arduino.h"
 
-void delay(unsigned long ms) {
-    uint32 start = millis();
-	do
-	{
-		yield();
-	}
-    while (millis() - start < ms);
+void delay(unsigned long ms)
+{
+    uint32 start = micros();
+    while (ms > 0)
+    {
+        yield();
+        while ( (ms > 0) && ((micros() - start) >= 1000) )
+        {
+            ms--;
+            start += 1000;
+        }
+    }
 }
 
 void delayMicroseconds(uint32 us) {


### PR DESCRIPTION
Fixes the improper sub-millisecond delay, as discussed here: https://github.com/rogerclarkmelbourne/Arduino_STM32/commit/85eb51aacb3b6ceaf1575112cd363eb9d3a4649b#commitcomment-29584548
Use working (tested) stock AVR code instead.