### PR TITLE
Add pgm_read_ptr and pgm_read_ptr_far for better compatibility with libs written for AVR

### DIFF
--- a/STM32F1/cores/maple/avr/pgmspace.h
+++ b/STM32F1/cores/maple/avr/pgmspace.h
@@ -31,6 +31,7 @@ typedef uint32_t prog_uint32_t;
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
+#define pgm_read_ptr(addr) (*(const void **)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)
@@ -40,5 +41,6 @@ typedef uint32_t prog_uint32_t;
 #define pgm_read_word_far(addr) pgm_read_word(addr)
 #define pgm_read_dword_far(addr) pgm_read_dword(addr)
 #define pgm_read_float_far(addr) pgm_read_float(addr)
+#define pgm_read_ptr_far(addr) pgm_read_ptr(addr)
 
 #endif


### PR DESCRIPTION
Ran into missing pgm_read_ptr while trying to compile NeoGPS for a blue pill. This is easily fixed by adding it to the existing pgmspace.h compatibility header. Also added pgm_read_ptr_far for consistency / completeness.

This change seems to be all that is needed to make NeoGPS work on STM32F1.