### PR TITLE
F4: USBD_StrDesc[] size fix

### DIFF
--- a/STM32F4/cores/maple/libmaple/usbF4/VCP/usbd_conf.h
+++ b/STM32F4/cores/maple/libmaple/usbF4/VCP/usbd_conf.h
@@ -32,7 +32,7 @@
   */
 #define USBD_CFG_MAX_NUM                1
 #define USBD_ITF_MAX_NUM                1
-#define USB_MAX_STR_DESC_SIZ            50
+#define USB_MAX_STR_DESC_SIZ            (64+4) // longest descriptor string length + 2
 
 /** @defgroup USB_VCP_Class_Layer_Parameter
   * @{


### PR DESCRIPTION
- bug: memory overflow for size values greater than 50, in function USBD_GetString(). Value 50 allows a max string length of 24 chars.

The array in question (USBD_StrDesc) is followed in memory by 2 fill bytes for the current compile order.
Arduino 1.8.6 compiles the files in different order, so that the USB will not work anymore.
The longest string is actually 32 bytes long (plus ending zero), this will be multiplied by 2, and 2 more bytes will be added at the beginning (https://github.com/rogerclarkmelbourne/Arduino_STM32/blob/master/STM32F4/cores/maple/libmaple/usbF4/STM32_USB_Device_Library/Core/src/usbd_req.c#L818-L834).
The last 2 bytes now are fill bytes (for align 4).