### PR TITLE
Fix clearing of TIMx_SR register

### DIFF
--- a/STM32F1/system/libmaple/timer_private.h
+++ b/STM32F1/system/libmaple/timer_private.h
@@ -129,7 +129,7 @@ static inline __always_inline void dispatch_single_irq(timer_dev *dev,
         void (*handler)(void) = dev->handlers[iid];
         if (handler) {
             handler();
-            regs->SR &= ~irq_mask;
+            regs->SR = ~irq_mask;
         }
     }
 }
@@ -165,7 +165,7 @@ static inline __always_inline void dispatch_adv_trg_com(timer_dev *dev) {
     handle_irq(dsr, TIMER_SR_TIF,   hs, TIMER_TRG_INTERRUPT, handled);
     handle_irq(dsr, TIMER_SR_COMIF, hs, TIMER_COM_INTERRUPT, handled);
 
-    regs->SR &= ~handled;
+    regs->SR = ~handled;
 }
 
 static inline __always_inline void dispatch_adv_cc(timer_dev *dev) {
@@ -179,7 +179,7 @@ static inline __always_inline void dispatch_adv_cc(timer_dev *dev) {
     handle_irq(dsr, TIMER_SR_CC2IF, hs, TIMER_CC2_INTERRUPT, handled);
     handle_irq(dsr, TIMER_SR_CC1IF, hs, TIMER_CC1_INTERRUPT, handled);
 
-    regs->SR &= ~handled;
+    regs->SR = ~handled;
 }
 
 static inline __always_inline void dispatch_general(timer_dev *dev) {
@@ -195,7 +195,7 @@ static inline __always_inline void dispatch_general(timer_dev *dev) {
     handle_irq(dsr, TIMER_SR_CC1IF, hs, TIMER_CC1_INTERRUPT,    handled);
     handle_irq(dsr, TIMER_SR_UIF,   hs, TIMER_UPDATE_INTERRUPT, handled);
 
-    regs->SR &= ~handled;
+    regs->SR = ~handled;
 }
 
 /* On F1 (XL-density), F2, and F4, TIM9 and TIM12 are restricted
@@ -211,7 +211,7 @@ static inline __always_inline void dispatch_tim_9_12(timer_dev *dev) {
     handle_irq(dsr, TIMER_SR_CC1IF, hs, TIMER_CC1_INTERRUPT,    handled);
     handle_irq(dsr, TIMER_SR_UIF,   hs, TIMER_UPDATE_INTERRUPT, handled);
 
-    regs->SR &= ~handled;
+    regs->SR = ~handled;
 }
 
 /* On F1 (XL-density), F2, and F4, timers 10, 11, 13, and 14 are
@@ -225,7 +225,7 @@ static inline __always_inline void dispatch_tim_10_11_13_14(timer_dev *dev) {
     handle_irq(dsr, TIMER_SR_CC1IF, hs, TIMER_CC1_INTERRUPT,    handled);
     handle_irq(dsr, TIMER_SR_UIF,   hs, TIMER_UPDATE_INTERRUPT, handled);
 
-    regs->SR &= ~handled;
+    regs->SR = ~handled;
 }
 
 static inline __always_inline void dispatch_basic(timer_dev *dev) {


### PR DESCRIPTION
To clear specific bits in TIMx_SR registers, libmaple uses

```
  TIMx_SR &= ~(events_handled);  // wrong
```

This is wrong. The `&=` operator expands to a read-modify-write sequence consisting of multiple instructions. If a new event occurs between the read from TIMx_SR and the write to TIMx_SR, that new event will be cleared immediately without ever being noticed or handled.

A better way to clear specific bits is

```
  TIMx_SR = ~(events_handled);  // good
```

This writes '0' to the bits to be cleared, and '1' to all other bits. The hardware will not allow software to change any SR bits from 0 to 1; only hardware events can do that. So bits written as '1' are effectively ignored and bits written as '0' are cleared. Exactly what we need.

I tested this in my program which captures input on TIM4_CH1 while simultaneously tracking TIM4 overflow events. Without this fix, timer overflow events are sometimes lost if a capture event occurs just before the timer overflows. This fix solves it.