### PR TITLE
Remove exit() and atexit() handlers from libc.

### DIFF
--- a/STM32F1/cores/maple/libc_repl.c
+++ b/STM32F1/cores/maple/libc_repl.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+int __wrap_atexit(void (*function)(void) __attribute__((unused))) { return 0; }
+
+int __wrap___cxa_atexit(void (*func) (void *) __attribute__((unused)), void * arg __attribute__((unused)), void * dso_handle __attribute__((unused))) { return 0; }
+
+__attribute__((noreturn)) void __wrap_exit(int status __attribute__((unused))) { while(1); }

--- a/STM32F1/cores/maple/rules.mk
+++ b/STM32F1/cores/maple/rules.mk
@@ -21,6 +21,7 @@ CFLAGS_$(d) := $(LIBMAPLE_INCLUDES) $(WIRISH_INCLUDES) -I$(d)
 sSRCS_$(d) := start.S
 cSRCS_$(d) := start_c.c
 cSRCS_$(d) += syscalls.c
+cSRCS_$(d) += libc_repl.c
 cSRCS_$(d) += $(MCU_SERIES)/util_hooks.c
 cppSRCS_$(d) := boards.cpp
 cppSRCS_$(d) += cxxabi-compat.cpp

--- a/STM32F1/platform.txt
+++ b/STM32F1/platform.txt
@@ -89,7 +89,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mcpu={b
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -lm -lgcc -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--warn-unresolved-symbols -Wl,--start-group {object_files} "{archive_file_path}" -Wl,--end-group
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} "-T{build.variant.path}/{build.ldscript}" "-Wl,--wrap=atexit,--wrap=__cxa_atexit,--wrap=exit" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -lm -lgcc -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--warn-unresolved-symbols -Wl,--start-group {object_files} "{archive_file_path}" -Wl,--end-group
 
 ## Create eeprom
 recipe.objcopy.eep.pattern=


### PR DESCRIPTION
This is the last of the basic memory use cleanups - all revolving around removing static object cleanup handlers and the associated dynamic memory management code, which is included in all built projects, but never used.

NOTE: Original Arduino cores also replace atexit with dummy handler.

exit()/atexit() handling is *only* for when main exits, which is not
possible in the Arduino environment.

We use the gcc linker to mangle these symbols and replace them with
our own library.  Symbols are stong in the default library, so simple
overloading does not work.

Total saving around 5k of flash and 2k of ram - all for functionality
which is linked in but never used.

* all patches are independant and functional, but most saving is with
all patches included.