### PR TITLE
Protect _settings[] array from accesses beyond end

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -554,12 +554,16 @@ void SPIClass::onReceive(void(*callback)(void)) {
     _currentSetting->receiveCallback = callback;
     if (callback){
         switch (_currentSetting->spi_d->clk_id) {
+            #if BOARD_NR_SPI >= 1
         case RCC_SPI1:
             dma_attach_interrupt(_currentSetting->spiDmaDev, _currentSetting->spiRxDmaChannel, &SPIClass::_spi1EventCallback);
             break;
+            #endif
+            #if BOARD_NR_SPI >= 2
         case RCC_SPI2:
             dma_attach_interrupt(_currentSetting->spiDmaDev, _currentSetting->spiRxDmaChannel, &SPIClass::_spi2EventCallback);
             break;
+            #endif
             #if BOARD_NR_SPI >= 3
         case RCC_SPI3:
             dma_attach_interrupt(_currentSetting->spiDmaDev, _currentSetting->spiRxDmaChannel, &SPIClass::_spi3EventCallback);
@@ -578,12 +582,16 @@ void SPIClass::onTransmit(void(*callback)(void)) {
     _currentSetting->transmitCallback = callback;
     if (callback){
         switch (_currentSetting->spi_d->clk_id) {
+            #if BOARD_NR_SPI >= 1
         case RCC_SPI1:
             dma_attach_interrupt(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &SPIClass::_spi1EventCallback);
             break;
-        case RCC_SPI2:
+            #endif
+            #if BOARD_NR_SPI >= 2
+       case RCC_SPI2:
             dma_attach_interrupt(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &SPIClass::_spi2EventCallback);
             break;
+            #endif
             #if BOARD_NR_SPI >= 3
         case RCC_SPI3:
             dma_attach_interrupt(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel, &SPIClass::_spi3EventCallback);
@@ -686,14 +694,18 @@ uint8 SPIClass::recv(void) {
     DMA call back functions, one per port.
 */
 
+#if BOARD_NR_SPI >= 1
 void SPIClass::_spi1EventCallback()
 {
     reinterpret_cast<class SPIClass*>(_spi1_this)->EventCallback();
 }
+#endif
 
+#if BOARD_NR_SPI >= 2
 void SPIClass::_spi2EventCallback() {
     reinterpret_cast<class SPIClass*>(_spi2_this)->EventCallback();
 }
+#endif
 #if BOARD_NR_SPI >= 3
 void SPIClass::_spi3EventCallback() {
     reinterpret_cast<class SPIClass*>(_spi3_this)->EventCallback();

--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -120,16 +120,20 @@ SPIClass::SPIClass(uint32 spi_num)
 
     // Init things specific to each SPI device
     // clock divider setup is a bit of hack, and needs to be improved at a later date.
+#if BOARD_NR_SPI >= 1
     _settings[0].spi_d = SPI1;
     _settings[0].clockDivider = determine_baud_rate(_settings[0].spi_d, _settings[0].clock);
     _settings[0].spiDmaDev = DMA1;
     _settings[0].spiTxDmaChannel = DMA_CH3;
     _settings[0].spiRxDmaChannel = DMA_CH2;
+#endif
+#if BOARD_NR_SPI >= 2
     _settings[1].spi_d = SPI2;
     _settings[1].clockDivider = determine_baud_rate(_settings[1].spi_d, _settings[1].clock);
     _settings[1].spiDmaDev = DMA1;
     _settings[1].spiTxDmaChannel = DMA_CH5;
     _settings[1].spiRxDmaChannel = DMA_CH4;
+#endif
 #if BOARD_NR_SPI >= 3
     _settings[2].spi_d = SPI3;
     _settings[2].clockDivider = determine_baud_rate(_settings[2].spi_d, _settings[2].clock);

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -161,8 +161,12 @@ private:
     Should move this to within the class once tested out, just for tidyness
 */
 static uint8_t ff = 0XFF;
+#if BOARD_NR_SPI >= 1
 static void (*_spi1_this);
+#endif
+#if BOARD_NR_SPI >= 2
 static void (*_spi2_this);
+#endif
 #if BOARD_NR_SPI >= 3
 static void (*_spi3_this);
 #endif
@@ -411,8 +415,12 @@ private:
 
     void EventCallback(void);
 
+    #if BOARD_NR_SPI >= 1
     static void _spi1EventCallback(void);
+    #endif
+    #if BOARD_NR_SPI >= 2
     static void _spi2EventCallback(void);
+    #endif
     #if BOARD_NR_SPI >= 3
     static void _spi3EventCallback(void);
     #endif

--- a/STM32F4/libraries/SPI/src/SPI.cpp
+++ b/STM32F4/libraries/SPI/src/SPI.cpp
@@ -124,6 +124,7 @@ SPIClass::SPIClass(uint32 spi_num) {
 // SPI2:  1 / 0 / 3     - 1 / 0 / 4
 // SPI3:  1 / 0 / 0 (2) - 1 / 0 / 5 (7)
 /*****************************************************************************/
+#if BOARD_NR_SPI >= 1
 	_settings[0].spi_d = SPI1;
 	_settings[0].clockDivider = determine_baud_rate(_settings[0].spi_d, _settings[0].clock);
 #ifdef SPI_DMA
@@ -132,6 +133,8 @@ SPIClass::SPIClass(uint32 spi_num) {
 	_settings[0].spiRxDmaStream  = DMA_STREAM0; // alternative: DMA_STREAM2
 	_settings[0].spiTxDmaStream  = DMA_STREAM3; // alternative: DMA_STREAM5
 #endif
+#endif
+#if BOARD_NR_SPI >= 2
 	_settings[1].spi_d = SPI2;
 	_settings[1].clockDivider = determine_baud_rate(_settings[1].spi_d, _settings[1].clock);
 #ifdef SPI_DMA
@@ -139,6 +142,7 @@ SPIClass::SPIClass(uint32 spi_num) {
 	_settings[1].spiDmaChannel = DMA_CH0;
 	_settings[1].spiRxDmaStream  = DMA_STREAM3; // alternative: -
 	_settings[1].spiTxDmaStream  = DMA_STREAM4; // alternative: -
+#endif
 #endif
 #if BOARD_NR_SPI >= 3
 	_settings[2].spi_d = SPI3;


### PR DESCRIPTION
_settings[] array is accessed beyond the end of the array if BOARD_NR_SPI is defined as 1 on for example the HyTiny board.

Running NodeManager/MySensors software crashes with a SIGSEGV due to SPI issue where _settings[] array is written to beyond the end of the array and places the address of dma1() in the getTimePtr in the Arduino Time.cpp library.  This occurs when _settings[1].spiRxDmaChannel is assigned DMA_CH4 in SPI.cpp on the HyTiny where the _settings[] array is only one element long.