### PR TITLE
Fixed incorrect arguments for stlink_upload

### DIFF
--- a/tools/linux/stlink_upload
+++ b/tools/linux/stlink_upload
@@ -1,5 +1,5 @@
 #!/bin/bash
-$(dirname $0)/stlink/st-flash write "$4" 0x8000000
+$(dirname $0)/stlink/st-flash write "$1" 0x8000000
 exit 0
 
 ## Remove the lines 2 and 3 (above) if you want this script to wait until the Serial device has been enumerated and loaded before the script exits

--- a/tools/linux64/stlink_upload
+++ b/tools/linux64/stlink_upload
@@ -28,7 +28,7 @@ USBRESET=$(which usb-reset) || USBRESET="./usb-reset"
 LEAF_STATUS=$(leaf_status)
 echo "USB Status [$LEAF_STATUS]"
 
-$(dirname $0)/stlink/st-flash write "$4" 0x8000000
+$(dirname $0)/stlink/st-flash write "$1" 0x8000000
 
 sleep 4
 # Reset the usb device to bring up the tty rather than DFU

--- a/tools/macosx/stlink_upload
+++ b/tools/macosx/stlink_upload
@@ -1,2 +1,2 @@
 #!/bin/bash
-$(dirname $0)/stlink/st-flash write "$4" 0x8000000 
+$(dirname $0)/stlink/st-flash write "$1" 0x8000000 


### PR DESCRIPTION
The number of arguments being passed to the stlink_upload script on
linux, linux64, macosx is one (this may have been more in the past but
the with version 1.8.8) this is now only a single argument.

The change changes the variable referenced in the script from $4 to $1.

This change already appears to have been applied to the windows version
of the script.

This appears to be open issue also #604 