### PR TITLE
bugfix:HardwareSerial check framing or parity error

### DIFF
--- a/STM32F1/system/libmaple/usart_private.h
+++ b/STM32F1/system/libmaple/usart_private.h
@@ -44,14 +44,19 @@ static inline __always_inline void usart_irq(ring_buffer *rb, ring_buffer *wb, u
      * See table 198 (sec 27.4, p809) in STM document RM0008 rev 15.
      * We enable RXNEIE. */
     if ((regs->CR1 & USART_CR1_RXNEIE) && (regs->SR & USART_SR_RXNE)) {
+        if( regs->SR & USART_SR_FE || regs->SR & USART_SR_PE ) {
+           // framing error or parity error
+           regs->DR; //read and throw away the data, this clears FE and PE as well
+       } else {
 #ifdef USART_SAFE_INSERT
-        /* If the buffer is full and the user defines USART_SAFE_INSERT,
-         * ignore new bytes. */
-        rb_safe_insert(rb, (uint8)regs->DR);
+            /* If the buffer is full and the user defines USART_SAFE_INSERT,
+            * ignore new bytes. */
+            rb_safe_insert(rb, (uint8)regs->DR);
 #else
-        /* By default, push bytes around in the ring buffer. */
-        rb_push_insert(rb, (uint8)regs->DR);
+            /* By default, push bytes around in the ring buffer. */
+            rb_push_insert(rb, (uint8)regs->DR);
 #endif
+       }
     }
     /* TXE signifies readiness to send a byte to DR. */
     if ((regs->CR1 & USART_CR1_TXEIE) && (regs->SR & USART_SR_TXE)) {


### PR DESCRIPTION
Currently HardwareSerial uart does not check if a framing error
(parity error or invalid stop bit) has occured and simply
forward the received byte to the caller. This results in spurious
invalid data being received e.g. when the uart pin is left floating
or when a connected device is reset. This confuses apps using uart,
and cause apps to abort with errors.

this fix checks received bytes for framing error (parity error or
stop bit errors) and discards them if a framing error occured