### PR TITLE
RTC Adjustment examples

### DIFF
--- a/STM32F1/libraries/RTClock/examples/RTCAdj/RTCAdjust.ino
+++ b/STM32F1/libraries/RTClock/examples/RTCAdj/RTCAdjust.ino
@@ -1,0 +1,245 @@
+/*
+ * RTCAdjust.cpp
+ *
+ *  Created on: Dec 10, 2018
+ *
+ *  @license MIT use at your own risk
+ *
+ *  Copyright 2018 andrew goh
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <Arduino.h>
+#include "rtadjust.h"
+
+/* note that the adjustment functions needs this RTClock
+ * if you rename variable rt, update rtadjust.h so that the
+ * extern refers to this RTClock*/
+RTClock rt(RTCSEL_LSE); // initialise
+
+#define BUFLEN 100
+uint8_t ind = 0;
+char cmd = 0;
+char buf[BUFLEN];
+tm_t tm;
+
+enum LineState {
+	KEY,
+	LINE
+} state;
+
+void processkey();
+void showtime();
+void synctime(char *buf, int len);
+void settime(char *buf, int len);
+void calibrate(char *buf, int len);
+void setdriftdur(char *buf, int len);
+void help();
+void clearbuf();
+
+void setup() {
+	state = LineState::KEY;
+
+	Serial.begin(115200);
+
+	/* initialise access to backup registers,
+	 * this is necessary due to the use of backup registers */
+	bkp_init();
+
+	/* adjust rtc */
+	adjtime();
+
+	//turn on the led basic check
+	//pinMode(LED_BUILTIN, OUTPUT);
+	//digitalWrite(LED_BUILTIN, HIGH);
+}
+
+void loop() {
+	if(Serial.available())
+		processkey();
+	else
+		delay(1);
+}
+
+void processkey() {
+	char c = Serial.read();
+	//echo the char;
+	Serial.print(c);
+	if( state == LineState::LINE ) {
+		if (ind < BUFLEN && c != '\r') {
+			if(c == 8 || c == 127 ) // backspace
+				ind--;
+			else
+				buf[ind++] = c; // copy the chars into buf
+		} else {
+			switch(cmd) {
+			case 's':
+				synctime(buf,ind);
+				break;
+			case 'T':
+				settime(buf,ind);
+				break;
+			case 'c':
+				calibrate(buf,ind);
+				break;
+			case 'x':
+				setdriftdur(buf,ind);
+				break;
+			default:
+				break;
+			}
+			state = LineState::KEY;
+			cmd = 0;
+			clearbuf();
+		}
+	} else {
+		switch(c) {
+		case 't':
+			showtime();
+			break;
+		case 's':
+			state = LineState::LINE;
+			clearbuf();
+			cmd = 's';
+			break;
+		case 'T':
+			state = LineState::LINE;
+			clearbuf();
+			cmd = 'T';
+			break;
+		case 'c':
+			state = LineState::LINE;
+			clearbuf();
+			cmd = 'c';
+			break;
+		case 'x':
+			state = LineState::LINE;
+			clearbuf();
+			cmd = 'x';
+			break;
+		case 'h':
+		case 'H':
+		case '?':
+			help();
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+
+void showtime() {
+    // get and print actual RTC timestamp
+    rt.breakTime(rt.now(), tm);
+    memset(buf,0,BUFLEN);
+    sprintf(buf, "RTC timestamp: %u-%u-%u, %02u:%02u:%02u",
+    		tm.year+1970, tm.month, tm.day, tm.hour, tm.minute, tm.second);
+    Serial.println(buf);
+    clearbuf();
+
+    Serial.print("last adj:");
+    rt.breakTime(getbkptime(), tm);
+    memset(buf,0,BUFLEN);
+    sprintf(buf, "RTC timestamp: %u-%u-%u, %02u:%02u:%02u",
+    		tm.year+1970, tm.month, tm.day, tm.hour, tm.minute, tm.second);
+    Serial.println(buf);
+    clearbuf();
+
+    Serial.print(F("drift duration, number of seconds for the stm32 rtc to drift 1 secs (faster):"));
+    Serial.println(getdrift());
+
+    Serial.print(F("BKP_RTCCR:"));
+    Serial.println(getrtccr());
+}
+
+void synctime(char *buf, int len) {
+	if (len == BUFLEN) buf[BUFLEN-1] = 0; //terminate the string for safety
+	if(parsetimestamp(buf, tm) <0) {
+		Serial.println(F("invalid date/time"));
+		return;
+	}
+
+	time_t time = rt.makeTime(tm);
+	/* this call the actual function to set the RTC and update
+	 * the last adjusted time simultaneously
+	 */
+	synctime(time);
+}
+
+
+
+void calibrate(char *buf, int len) {
+	if (len == BUFLEN) buf[BUFLEN-1] = 0; //terminate the string for safety
+	if(parsetimestamp(buf, tm) <0) {
+		Serial.println(F("invalid date/time"));
+		return;
+	}
+
+	time_t time = rt.makeTime(tm);
+
+	/* this call the calibratertc() function to calculate
+	 * the drift duration
+	 */
+	calibratertc(time);
+}
+
+/*
+ * this function sets the rtc directly by-passing all the adjustments
+ *
+ * note that this function is used during tests to simulate drifts etc
+ * hence it is not features in help();
+ *
+ * in a normal context use synctime() to set the RTC time so that
+ * the last adjustment date/time is updated as well
+ */
+void settime(char *buf, int len) {
+	if (len == BUFLEN) buf[BUFLEN-1] = 0; //terminate the string for safety
+	if(parsetimestamp(buf, tm) <0) {
+		Serial.println(F("invalid date/time"));
+		return;
+	}
+
+	rt.setTime(tm);
+}
+
+void setdriftdur(char *buf, int len) {
+	if (len == BUFLEN) buf[BUFLEN-1] = 0; //terminate the string for safety
+	int16_t drift_dur = atoi(buf);
+	/* this funciton updates the drift duration directly */
+	setbkpdrift(drift_dur);
+}
+
+void help() {
+	Serial.println(F("h, H, ? - display help, this message"));
+	Serial.println(F("t - current time"));
+	Serial.println(F("sYYYY-MM-DD HH:MM:SS - sync/set time"));
+	Serial.println(F("cYYYY-MM-DD HH:MM:SS - calibrate rtc"));
+	Serial.println(F("where YYYY-MM-DD HH:MM_SS - is the current accurate time"));
+	Serial.println(F("xnnnn - set the drift duration where nnnn is the drift duration"));
+	Serial.println(F("        number of seconds for the stm32 rtc to drift 1 secs (faster)"));
+	Serial.println(F("the s, c, x commands needs to end with a carriage return at the end of line"));
+	Serial.println();
+}
+
+void clearbuf() {
+	ind = 0;
+	memset(buf,0,BUFLEN);
+}
+

--- a/STM32F1/libraries/RTClock/examples/RTCAdj/readme.md
+++ b/STM32F1/libraries/RTClock/examples/RTCAdj/readme.md
@@ -1,0 +1,131 @@
+# stm32duino RTC drift adjustment
+
+This Arduino sketch is built based on Stm32duino libmaple core.
+It provides an example of how one could adjust for RTC (real time clock) drifts if one is using a 32k crystal that drift significantly.
+
+For drifts that is less than (304 secs ~ 5 minutes) per month. STM has published an appnote for a different means of slowing down the RTC clock
+[AN2604 STM32F101xx and STM32F103xx RTC calibration](https://www.st.com/content/ccc/resource/technical/document/application_note/ff/c1/4f/86/4e/29/42/d1/CD00167326.pdf/files/CD00167326.pdf/jcr:content/translations/en.CD00167326.pdf). This is possibly simpler and more accurate. *this feature has been added in this implementation*
+
+Due to the use of backup registers, you need to power the board/stm32 on VBAT (e.g. using a coin cell) so that the backup memory is maintained. And as the last adjusted date/time (saved in backup register 8 and 9) and drift duration (saved in backup register 7), if power is removed and the backup memory is lost, you would need to re-do the calibration again.  
+
+## Building and running the sketch
+
+Build and run the sketch based on STM32duino libmaple core using the Arduino IDE.
+The files relevant to the sketch are:
+
+* RTCAdjust.ino - this is the sketch itself
+* rtadjust.h    - utility functions for the adjustments
+* rtadjust.cpp  - utility functions for the adjustments
+
+The sketch is a demo that runs on the serial console, the commands on the serial console are
+
+* h, H, ? - display help this message
+* t - display current time
+* sYYYY-MM-DD HH:MM:SS - sync/set time
+* cYYYY-MM-DD HH:MM:SS - calibrate rtc  
+  where YYYY-MM-DD HH:MM_SS - is the current accurate time
+* xnnnn - set the drift duration where nnnn is the drift duration  
+        number of seconds for the stm32 rtc to drift 1 secs (faster)
+
+t command displays the time and some additional info related to the adjustments e.g.  
+```
+RTC timestamp: 2018-12-10, 00:00:01  
+last adj:RTC timestamp: 2018-12-10, 00:00:00  
+drift duration, number of seconds for the stm32 rtc to drift 1 secs (faster): 3350
+```
+## How do the adjustments work
+
+In your wiring/arduino setup() function, make it call the function *adjtime();*, e.g.
+```
+void setup() {
+  /* initialise access to backup registers,
+   * this is necessary due to the use of backup registers */
+  bkp_init();
+
+  /* adjust rtc */
+  adjtime();
+}
+```
+This function would make RTC adjustments based a calibrated drift duration or offset which i named as the drift duration. The drift duration is number of seconds for the stm32 rtc to drift 1 seconds (faster)
+
+
+## How to do the calibrations using the demo sketch / app
+
+This app/sketch itself has the commands to do the calibration. To do the calibration:
+
+1. run  sYYYY-MM-DD HH:MM:SS - sync/set time  
+   where YYYY-MM-DD HH:MM_SS - is the current accurate date/time
+   This would set the RTC and the last adjustment date/time  to the date / time you supplied.  
+   The last adjustment date/time is saved in 2 backup registers 8 and 9.
+   
+2. after a day or more, a longer period cumulates more drift and increase accuracy  
+   run cYYYY-MM-DD HH:MM:SS - calibrate rtc  
+   where YYYY-MM-DD HH:MM_SS - is the current accurate date/time at the time you do the calibration. 
+
+   This would compute the drift duration and save it in backup register 7.
+   
+3. reset the device and check the time after the calibration. if setup() calls adjtime(), the RTC would show the drift adjusted/compensated date/time.
+
+## How to do the adjustments and calibrations work in actual code?
+
+1. in setup() run adjtime() 
+```
+void setup() {
+  /* initialise access to backup registers,
+   * this is necessary due to the use of backup registers */
+  bkp_init();
+
+  /* adjust rtc */
+  adjtime();
+}
+```
+This would make the adjustments every time the sketch is started.
+Note that adjtime() does the adjustment no more than once in 24 hours. This design is to prevent frequent adjustments which could result in cumulative errors as the granuality of adjustments is 1 sec. if you prefer for the adjustments to be more frequent you could comment the statement in the function.
+
+2. The function to set the RTC and last adjusted date time is:  
+```
+/*  synctime() set the RTC clock and saves the time in backup register 8 and 9
+ *  as the time of the last adjustment
+ *
+ *  call this function with the current accurate clock time to set the rtc
+ *
+ *  @param time the time_t value of the current accurate clock time
+ */
+void synctime(time_t time_now);
+```
+
+3. The function to perform the RTC calibration to compute the drift duration is
+```
+/*  this function calibrate the rtc by computing the drift_duration
+ *
+ *  call this function with the current accurate clock time to calibrate the rtc
+ *
+ *  if the cumulative delay between current time and the last time when synctime()
+ *  is called is lower than 100, a warning would be displayed that the drift
+ *  granulity is low and may result in inaccuracy of the rtc adjustments
+ *
+ *  note that this function can only be run once to compute the drift_duration
+ *  this is because the time of last adjustment would have been updated
+ *  by adjtime() after calibration and is no longer relevant for purpose of
+ *  computing drift duration
+ *
+ *  to run it again
+ *  1) first zero out drift duration using setbkpdrift(0)
+ *     or disconnect VBAT and power to clear backup memory
+ *  next repeat the calibration cycle
+ *  2) run synctime(time_now) with the accurate clock time
+ *  3) after a day or more (longer period cumulates more drift and increase accuracy)
+ *     run calibrate(time_now) with the accurate clock time
+ *
+ *  @param time the time_t value of the current accurate clock time
+ */
+void calibratertc(time_t time_now);
+```
+
+4. Dependencies, in the main sketch:
+```
+/* note that the adjustment functions needs this RTClock
+ * if you rename variable rt, update rtadjust.h so that the
+ * extern refers to this RTClock*/
+RTClock rt(RTCSEL_LSE); // initialise
+```

--- a/STM32F1/libraries/RTClock/examples/RTCAdj/rtadjust.cpp
+++ b/STM32F1/libraries/RTClock/examples/RTCAdj/rtadjust.cpp
@@ -1,0 +1,254 @@
+/*
+ * RTCAdjust.cpp
+ *
+ *  Created on: Dec 10, 2018
+ *
+ *  @license MIT use at your own risk
+ *
+ *  Copyright 2018 andrew goh
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <Arduino.h>
+#include <RTClock.h>
+#include "rtadjust.h"
+
+/* adjust RTC time
+ * call this from setup() so that the sketch updates the rtc when starting up
+ */
+void adjtime() {
+	int adj;
+	time_t now = rt.getTime();
+	int last = getbkptime();
+	int dur = now - last;
+
+	/* adjust time no more than once in 24 hours
+	 * multiple adjustments could result in cumulative errors
+	 * comment this if you prefer to adjust every time
+	 */
+	if(now - last < 24 * 60 * 60) return;
+
+	int driftdur = getdrift();
+	if(driftdur != 0) {
+		adj = dur / driftdur ; // number of sec to subtract
+		now -= adj; // subtracting as the clock runs fast, change this if you are 'speeding up' the rtc
+		rt.setTime(now);
+		setbkptime(now);
+	}
+}
+
+/*  synctime() set the RTC clock and saves the time in backup register 8 and 9
+ *  as the time of the last adjustment
+ *
+ *  call this function with the current accurate clock time to set the rtc
+ *
+ *  @param time the time_t value of the current accurate clock time
+ */
+void synctime(time_t time_now) {
+	rt.setTime(time_now);
+	setbkptime(time_now);
+}
+
+
+/*  this function calibrate the rtc by computing the drift_duration
+ *
+ *  call this function with the current accurate clock time to calibrate the rtc
+ *
+ *  if the cumulative delay between current time and the last time when synctime()
+ *  is called is lower than 100, a warning would be displayed that the drift
+ *  granulity is low and may result in inaccuracy of the rtc adjustments
+ *
+ *  note that this function can only be run once to compute the drift_duration
+ *  this is because the time of last adjustment would have been updated
+ *  by adjtime() after calibration and is no longer relevant for purpose of
+ *  computing drift duration
+ *
+ *  to run it again
+ *  1) first zero out drift duration using setbkpdrift(0)
+ *     or disconnect VBAT and power to clear backup memory
+ *  next repeat the calibration cycle
+ *  2) run synctime(time_now) with the accurate clock time
+ *  3) after a day or more (longer period cumulates more drift and increase accuracy)
+ *     run calibrate(time_now) with the accurate clock time
+ *
+ *  @param time the time_t value of the current accurate clock time
+ */
+void calibratertc(time_t time_now) {
+
+	int cur_drift = getdrift();
+	if(cur_drift != 0) {
+		Serial.print(F("err: rtc has been calibrated prior, "));
+		Serial.println(F("zero out drift duration before calibrating again"));
+		return;
+	}
+	int last = getbkptime();
+	int now = rt.getTime();
+	int elapsed = time_now - last;
+	Serial.print(F("elapsed (s):"));
+	Serial.println(elapsed);
+	int drift = now - time_now ;
+	Serial.print(F("drift (s):"));
+	Serial.println(drift);
+	if (drift < 100) {
+		Serial.print(F("warn: drift granuity is low, 1 sec difference results in "));
+		float d = 100.0 / (drift + 1.0);
+		Serial.print(d);
+		Serial.println(F(" % error"));
+	}
+	int drift_dur = elapsed / drift;
+    Serial.print(F("drift duration, number of seconds for the stm32 rtc to drift 1 secs (faster):"));
+    Serial.println(drift_dur);
+    int rtccr_max = 1048576 / 127;
+    if(drift_dur > rtccr_max) { //about less than 314 secs ~ 5 mins drift per month
+ /* if the drift is better than 1048576 / 127 ~ 1:8256 the rtc hardware can do the
+  * adjustment, in this case just setup BKP_RTCCR register calibration value and let the
+  * RTC hardware take care of the drift adjustment. this only works if the RTC
+  * runs faster than accurate time
+  *
+  * see AN2604 STM32F101xx and STM32F103xx RTC calibration
+  * https://www.st.com/content/ccc/resource/technical/document/application_note/ff/c1/4f/86/4e/29/42/d1/CD00167326.pdf/files/CD00167326.pdf/jcr:content/translations/en.CD00167326.pdf
+  */
+    	uint8_t cal = drift_dur * 127 / 1048576;
+    	setrtccr(cal);
+    	//set the drift duration as zero - no software adjustments needed
+    	setbkpdrift(0);
+    } else if ( drift_dur > -32768 && drift_dur <= rtccr_max ) {
+    	setbkpdrift(drift_dur & 0xffff); //bkp register is only 16 bits
+    } else
+    	//drift duration < -32767 ! (about slower by less than 10 secs per month)
+    	//no adjustment can't store in 16 bit bkp register
+    	setbkpdrift(0);
+
+}
+
+/* set the time of last adjustment in backup register 8 and 9
+ * @param time this is the time_t value to be saved
+ */
+void setbkptime(time_t time) {
+	bkp_enable_writes();
+	bkp_write(8, time & 0xffff);
+	bkp_write(9, time >> 16);
+	bkp_disable_writes();
+}
+
+/* get the time of last adjustment from backup register 8 and 9
+ * @return the time_t value of the time saved
+ */
+time_t getbkptime() {
+	time_t time;
+	time = bkp_read(8);
+	time |= bkp_read(9) << 16;
+	return time;
+}
+
+/* save the drift duration in backup register 7
+ * number of seconds for the stm32 rtc to drift 1 secs (faster)
+ * from an accurate time source
+ *
+ * @param adj 	number of seconds for the stm32 rtc to drift 1 secs (faster)
+ * 				from an accurate time source
+ *
+ */
+void setbkpdrift(int16_t drift_dur) {
+	bkp_enable_writes();
+	bkp_write(7, drift_dur);
+	bkp_disable_writes();
+}
+
+/* get the drift duration from backup register 7
+ * @return 	number of seconds for the stm32 rtc to drift 1 secs (faster)
+ * 			from an accurate time source
+ *
+ */
+int16_t getdrift() {
+	return bkp_read(7);
+}
+
+/* update BKP_RTCCR register calibration value
+ * see AN2604 STM32F101xx and STM32F103xx RTC calibration
+ * https://www.st.com/content/ccc/resource/technical/document/application_note/ff/c1/4f/86/4e/29/42/d1/CD00167326.pdf/files/CD00167326.pdf/jcr:content/translations/en.CD00167326.pdf
+ * as well as RM0008 reference manual for stm32f1x section 6 Backup registers (BKP) page 80
+ * section 6.4.2 RTC clock calibration register (BKP_RTCCR) page 82
+ *
+ * @param cal the calibration value according to AN2604 STM32F101xx and STM32F103xx RTC calibration
+ *
+ */
+void setrtccr(uint8_t cal) {
+	bkp_enable_writes();
+	uint16_t val = 0;
+	//calibration value is the 1st 7 bits of RTCCR
+	//we zero out the other bits as it is not needed
+	BKP->regs->RTCCR = cal & 0x7f;
+	bkp_disable_writes();
+}
+
+/* retrieve the rtccr calibration value
+ *
+ * @return rtccr calibration value
+ */
+uint8_t getrtccr() {
+	return (BKP->regs->RTCCR) & 0x7f;
+}
+
+/* utility function to parse entered timestamp
+ * format yyyy-mm-dd hh:mm:ss
+ * */
+int8_t parsetimestamp(char *buf, tm_t &tm) {
+	int8_t i = 0;
+    char *token = strtok(buf, " -:"); // get first token
+    // walk through tokens
+    while( token != NULL ) {
+    	i++;
+    	int num = atoi(token);
+    	//Serial.print(i);
+    	//Serial.print(' ');
+    	//Serial.println(num);
+    	switch(i) {
+    	case 1:
+    		tm.year = num - 1970;
+    		break;
+    	case 2:
+    		tm.month = num;
+    		break;
+    	case 3:
+    		tm.day = num;
+    		break;
+    	case 4:
+    		tm.hour = num;
+    		break;
+    	case 5:
+    		tm.minute = num;
+    		break;
+    	case 6:
+    		tm.second = num;
+    		break;
+    	default:
+    		break;
+    	}
+		token = strtok(NULL, " -:"); // get next token
+    }
+    if (i==6) //if we have 6 tokens assume it is correct ;p
+    	return 0;
+    else
+    	return -1;
+}
+
+
+
+

--- a/STM32F1/libraries/RTClock/examples/RTCAdj/rtadjust.h
+++ b/STM32F1/libraries/RTClock/examples/RTCAdj/rtadjust.h
@@ -1,0 +1,128 @@
+/*
+ * rtadjust.h
+ *
+ *  Created on: Dec 10, 2018
+ *
+ *  @license MIT use at your own risk
+ *
+ *  Copyright 2018 andrew goh
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ *  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef RTADJUST_H_
+#define RTADJUST_H_
+#include <RTClock.h>
+
+/* adjust RTC time
+ * call this from setup() so that the sketch updates the rtc when starting up
+ */
+void adjtime();
+
+/*  synctime() set the RTC clock and saves the time in backup register 8 and 9
+ *  as the time of the last adjustment
+ *
+ *  call this function with the current accurate clock time to set the rtc
+ *
+ *  @param time the time_t value of the current accurate clock time
+ */
+void synctime(time_t time_now);
+
+/*  this function calibrate the rtc by computing the drift_duration
+ *
+ *  call this function with the current accurate clock time to calibrate the rtc
+ *
+ *  if the cumulative delay between current time and the last time when synctime()
+ *  is called is lower than 100, a warning would be displayed that the drift
+ *  granulity is low and may result in inaccuracy of the rtc adjustments
+ *
+ *  note that this function can only be run once to compute the drift_duration
+ *  this is because the time of last adjustment would have been updated
+ *  by adjtime() after calibration and is no longer relevant for purpose of
+ *  computing drift duration
+ *
+ *  to run it again
+ *  1) first zero out drift duration using setbkpdrift(0)
+ *     or disconnect VBAT and power to clear backup memory
+ *  next repeat the calibration cycle
+ *  2) run synctime(time_now) with the accurate clock time
+ *  3) after a day or more (longer period cumulates more drift and increase accuracy)
+ *     run calibrate(time_now) with the accurate clock time
+ *
+ *  @param time the time_t value of the current accurate clock time
+ */
+void calibratertc(time_t time_now);
+
+
+/* set the time of last adjustment in backup register 8 and 9
+ * @param time this is the time_t value to be saved
+ */
+void setbkptime(time_t time);
+
+
+/* get the time of last adjustment from backup register 8 and 9
+ * @return the time_t value of the time saved
+ */
+time_t getbkptime();
+
+
+/* save the drift duration in backup register 7
+ * number of seconds for the stm32 rtc to drift 1 secs (faster)
+ * from an accurate time source
+ *
+ * @param adj 	number of seconds for the stm32 rtc to drift 1 secs (faster)
+ * 				from an accurate time source
+ *
+ */
+void setbkpdrift(int16_t drift_dur);
+
+/* get the drift duration from backup register 7
+ * @return 	number of seconds for the stm32 rtc to drift 1 secs (faster)
+ * 			from an accurate time source
+ *
+ */
+int16_t getdrift();
+
+
+/* update BKP_RTCCR register calibration value
+ * see AN2604 STM32F101xx and STM32F103xx RTC calibration
+ * https://www.st.com/content/ccc/resource/technical/document/application_note/ff/c1/4f/86/4e/29/42/d1/CD00167326.pdf/files/CD00167326.pdf/jcr:content/translations/en.CD00167326.pdf
+ * as well as RM0008 reference manual for stm32f1x section 6 Backup registers (BKP) page 80
+ * section 6.4.2 RTC clock calibration register (BKP_RTCCR) page 82
+ *
+ * @param cal the calibration value according to AN2604 STM32F101xx and STM32F103xx RTC calibration
+ *
+ */
+void setrtccr(uint8_t cal);
+
+/* retrieve the rtccr calibration value
+ *
+ * @return rtccr calibration value
+ */
+uint8_t getrtccr();
+
+/* utility function to parse entered timestamp
+ * format yyyy-mm-dd hh:mm:ss
+ * */
+int8_t parsetimestamp(char *buf, tm_t &tm);
+
+/* note that the adjustment functions needs this RTClock
+ * if you rename variable rt, update this so that the
+ * extern refers to valid RTClock*/
+extern RTClock rt;
+
+#endif /* RTADJUST_H_ */


### PR DESCRIPTION
this PR replaces the old PR
https://github.com/rogerclarkmelbourne/Arduino_STM32/pull/581

this commit provides examples to adjust for RTC drifts
as discussed in thread
http://www.stm32duino.com/viewtopic.php?f=18&t=4365

it provides a new set of source files in
STM32F1/libraries/RTClock/examples/RTCAdj

these examples uses RTClock functionality
and do not affect/or change existing functionality