### PR TITLE
SPI: fix annoying unused variables warnings

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -86,6 +86,15 @@ static const spi_pins board_spi_pins[] __FLASH__ = {
 #endif
 };
 
+#if BOARD_NR_SPI >= 1
+static void (*_spi1_this);
+#endif
+#if BOARD_NR_SPI >= 2
+static void (*_spi2_this);
+#endif
+#if BOARD_NR_SPI >= 3
+static void (*_spi3_this);
+#endif
 
 /*
  * Constructor
@@ -375,17 +384,17 @@ uint8 SPIClass::transfer(uint8 byte) const
 uint16_t SPIClass::transfer16(uint16_t data) const
 {
     // Modified by stevestrong: write & read two consecutive bytes in 8 bit mode (DFF=0)
-	// This is more effective than two distinct byte transfers
+    // This is more effective than two distinct byte transfers
     spi_dev * spi_d = _currentSetting->spi_d;
     spi_rx_reg(spi_d);                   // read any previous data
     spi_tx_reg(spi_d, data>>8);          // write high byte
     while (spi_is_tx_empty(spi_d) == 0); // wait until TXE=1
     while (spi_is_busy(spi_d) != 0);     // wait until BSY=0
-	uint16_t ret = spi_rx_reg(spi_d)<<8; // read and shift high byte
+    uint16_t ret = spi_rx_reg(spi_d)<<8; // read and shift high byte
     spi_tx_reg(spi_d, data);             // write low byte
     while (spi_is_tx_empty(spi_d) == 0); // wait until TXE=1
     while (spi_is_busy(spi_d) != 0);     // wait until BSY=0
-	ret += spi_rx_reg(spi_d);            // read low byte
+    ret += spi_rx_reg(spi_d);            // read low byte
     return ret;
 }
 
@@ -691,16 +700,13 @@ uint8 SPIClass::recv(void) {
 }
 
 /*
-    DMA call back functions, one per port.
-*/
-
+ * DMA call back functions, one per port.
+ */
 #if BOARD_NR_SPI >= 1
-void SPIClass::_spi1EventCallback()
-{
+void SPIClass::_spi1EventCallback() {
     reinterpret_cast<class SPIClass*>(_spi1_this)->EventCallback();
 }
 #endif
-
 #if BOARD_NR_SPI >= 2
 void SPIClass::_spi2EventCallback() {
     reinterpret_cast<class SPIClass*>(_spi2_this)->EventCallback();
@@ -711,10 +717,10 @@ void SPIClass::_spi3EventCallback() {
     reinterpret_cast<class SPIClass*>(_spi3_this)->EventCallback();
 }
 #endif
-/*
-* Auxiliary functions
-*/
 
+/*
+ * Auxiliary functions
+ */
 static const spi_pins* dev_to_spi_pins(spi_dev *dev) {
     switch (dev->clk_id) {
 #if BOARD_NR_SPI >= 1
@@ -775,8 +781,8 @@ static const spi_baud_rate baud_rates[8] __FLASH__ = {
 */
 static spi_baud_rate determine_baud_rate(spi_dev *dev, uint32_t freq) {
     uint32_t clock = 0, i;
-    switch (rcc_dev_clk(dev->clk_id))
-    {
+    switch (rcc_dev_clk(dev->clk_id)) {
+    case RCC_AHB:
     case RCC_APB2: clock = STM32_PCLK2; break; // 72 Mhz
     case RCC_APB1: clock = STM32_PCLK1; break; // 36 Mhz
     }

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -158,18 +158,9 @@ private:
 
 
 /*
-    Should move this to within the class once tested out, just for tidyness
-*/
-static uint8_t ff = 0XFF;
-#if BOARD_NR_SPI >= 1
-static void (*_spi1_this);
-#endif
-#if BOARD_NR_SPI >= 2
-static void (*_spi2_this);
-#endif
-#if BOARD_NR_SPI >= 3
-static void (*_spi3_this);
-#endif
+ * Kept for compat.
+ */
+static const uint8_t ff = 0XFF;
 
 /**
  * @brief Wirish SPI interface.


### PR DESCRIPTION
- use const for ff variable to avoid unused variable on each SPI.h include
- move the spi_this refs where its used...
- and also the 3 others ones :

STM32F1\libraries\SPI\src\SPI.cpp:784:12
  warning: enumeration value 'RCC_AHB' not handled in switch [-Wswitch]

STM32F1\libraries\SPI\src\SPI.cpp:392:5:
  warning: this 'while' clause does not guard... [-Wmisleading-indentation]

Sample use : https://travis-ci.org/MarlinFirmware/Marlin/jobs/564740480