### PR TITLE
[bugfix] Restore overflowed memory copy

### DIFF
--- a/STM32F1/cores/maple/libmaple/usb/usb_lib/usb_mem.c
+++ b/STM32F1/cores/maple/libmaple/usb/usb_lib/usb_mem.c
@@ -59,24 +59,15 @@ void UserToPMABufferCopy(const u8 *pbUsrBuf, u16 wPMABufAddr, u16 wNBytes)
 *******************************************************************************/
 void PMAToUserBufferCopy(u8 *pbUsrBuf, u16 wPMABufAddr, u16 wNBytes)
 {
-  u32 n = (wNBytes + 1) >> 1;/* /2*/
-  u32 i;
-  u32 *pdwVal;
-  u8 *pbStartUsrBuf = pbUsrBuf;
-  u8 endVal;
-  if(wNBytes & 0x0001)
+  u16 * destPtr = (u16*)pbUsrBuf;
+  u32 * pdwVal = (u32 *)(wPMABufAddr * 2 + PMAAddr);
+  for (u16 i = wNBytes/2; i > 0; i--)
   {
-    endVal = pbStartUsrBuf[wNBytes];
+    *destPtr++ = (u16)*pdwVal++;
   }
-  pdwVal = (u32 *)(wPMABufAddr * 2 + PMAAddr);
-  for (i = n; i != 0; i--)
+  if (wNBytes & 0x1) // odd value ?
   {
-    *(u16*)pbUsrBuf++ = *pdwVal++;
-    pbUsrBuf++;
-  }
-  if(wNBytes & 1)
-  {
-    pbStartUsrBuf[wNBytes] = endVal;
+    *(u8*)destPtr = *(u8*)pdwVal;
   }
 }
 

--- a/STM32F1/cores/maple/libmaple/usb/usb_lib/usb_mem.c
+++ b/STM32F1/cores/maple/libmaple/usb/usb_lib/usb_mem.c
@@ -62,11 +62,21 @@ void PMAToUserBufferCopy(u8 *pbUsrBuf, u16 wPMABufAddr, u16 wNBytes)
   u32 n = (wNBytes + 1) >> 1;/* /2*/
   u32 i;
   u32 *pdwVal;
+  u8 *pbStartUsrBuf = pbUsrBuf;
+  u8 endVal;
+  if(wNBytes & 0x0001)
+  {
+    endVal = pbStartUsrBuf[wNBytes];
+  }
   pdwVal = (u32 *)(wPMABufAddr * 2 + PMAAddr);
   for (i = n; i != 0; i--)
   {
     *(u16*)pbUsrBuf++ = *pdwVal++;
     pbUsrBuf++;
+  }
+  if(wNBytes & 1)
+  {
+    pbStartUsrBuf[wNBytes] = endVal;
   }
 }
 


### PR DESCRIPTION
https://github.com/rogerclarkmelbourne/Arduino_STM32/blob/a3a56866505eeca4b49fc435700dcd4bd5540c8c/STM32F1/system/libmaple/include/libmaple/usb_cdcacm.h#L155
This structure takes up 7 bytes of RAM, under some memory-aligned compilation rules, it takes up 8bytes
This structural variable is passed into the 
`PMAToUserBufferCopy` function as a
` u8 * pbUsrBuf `parameter in here https://github.com/rogerclarkmelbourne/Arduino_STM32/blob/a3a56866505eeca4b49fc435700dcd4bd5540c8c/STM32F1/cores/maple/libmaple/usb/usb_lib/usb_mem.c#L60
If the length of the `pbUsrBuf` parameter is odd, it will tamper with the last byte of the address.
If the compiler is single-byte aligned, the structure `line_coding` takes up 7bytes, At this point, the value of the variable that follows `line_coding` will be tampered by `PMAToUserBufferCopy`.
for example：

> usb_cdcacm_line_coding line_coding;  //@RAM address 0x20000640
> uint8_t test = 0;   //@RAM address 0x20000647

The normal value of the `test` variable is 0. When the 

> PMAToUserBufferCopy((u8 *)&line_coding, xxx, 7)

 function has been executed
The value of the `test` variable will be tampered, not equal 0.

thie PR restored tampered data.

