### PR TITLE
Added missing extern C to STM32ADC helper files

### DIFF
--- a/STM32F1/libraries/STM32ADC/src/utility/util_adc.h
+++ b/STM32F1/libraries/STM32ADC/src/utility/util_adc.h
@@ -1,3 +1,7 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <libmaple/adc.h>
 
 
@@ -28,3 +32,7 @@ void set_continuous( adc_dev * dev);
 uint8 poll_adc_convert(adc_dev *dev);
 
 void adc_dma_enable(adc_dev * dev);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
when I tried to use STM32ADC::setChannels method I got an error about missing function implementation from util_adc.c file, which was caused by missing extern "C" declaration in util_adc.h file.