### PR TITLE
Remove errant "init" of extern

### DIFF
--- a/STM32F1/libraries/STM32ADC/src/utility/util_adc.c
+++ b/STM32F1/libraries/STM32ADC/src/utility/util_adc.c
@@ -7,7 +7,7 @@
     Interrupt function.
     This handles Analog watchdog and ADC1 and 2.
 */
-extern volatile unsigned int adc_result = 0;
+extern volatile unsigned int adc_result;
 
 /*
     Starts a single conversion in one channel previously defined.


### PR DESCRIPTION
Fix a compiler warning that an `extern` cannot be set in its declaration.