### PR TITLE
USBComposite: fix circular dependency

### DIFF
--- a/STM32F1/libraries/USBComposite/USBMIDI.h
+++ b/STM32F1/libraries/USBComposite/USBMIDI.h
@@ -34,7 +34,6 @@
 
 //#include <Print.h>
 #include <boards.h>
-#include <USBComposite.h>
 #include "usb_generic.h"
 
 /*

--- a/STM32F1/libraries/USBComposite/USBMassStorage.h
+++ b/STM32F1/libraries/USBComposite/USBMassStorage.h
@@ -2,7 +2,6 @@
 #define	USBMASSSTORAGE_H
 
 #include <boards.h>
-#include "USBComposite.h"
 #include "usb_generic.h"
 #include "usb_mass_mal.h"
 

--- a/STM32F1/libraries/USBComposite/USBXBox360.h
+++ b/STM32F1/libraries/USBComposite/USBXBox360.h
@@ -19,7 +19,6 @@
 
 #include <Print.h>
 #include <boards.h>
-#include "USBComposite.h"
 #include "usb_generic.h"
 
 class USBXBox360 {


### PR DESCRIPTION
*USBComposite.h* includes *USBMIDI.h*, *USBMassStorage.h* and *USBXBox360.h*
which include *USBComposite.h*.

Include guard in *USBComposite.h* prevents compile errors, but it
causes Qt Creator's clang code model to show errors and stop working.