### PR TITLE
fix: remove warning __always_inline not always possible

### DIFF
--- a/STM32F1/cores/maple/ext_interrupts.h
+++ b/STM32F1/cores/maple/ext_interrupts.h
@@ -106,7 +106,7 @@ void detachInterrupt(uint8 pin);
  *
  * @see noInterrupts()
  */
-static __always_inline void interrupts() {
+inline void interrupts() {
     nvic_globalirq_enable();
 }
 
@@ -120,7 +120,7 @@ static __always_inline void interrupts() {
  *
  * @see interrupts()
  */
-static __always_inline void noInterrupts() {
+inline void noInterrupts() {
     nvic_globalirq_disable();
 }
 

--- a/STM32F1/cores/maple/libmaple/exti.c
+++ b/STM32F1/cores/maple/libmaple/exti.c
@@ -250,7 +250,7 @@ __weak void __irq_exti15_10(void) {
  * won't actually be cleared in time and the ISR will fire again.  To
  * compensate, this function NOPs for 2 cycles after clearing the
  * pending bits to ensure it takes effect. */
-static __always_inline void clear_pending_msk(uint32 exti_msk) {
+inline void clear_pending_msk(uint32 exti_msk) {
     EXTI_BASE->PR = exti_msk;
     asm volatile("nop");
     asm volatile("nop");
@@ -258,7 +258,7 @@ static __always_inline void clear_pending_msk(uint32 exti_msk) {
 
 /* This dispatch routine is for non-multiplexed EXTI lines only; i.e.,
  * it doesn't check EXTI_PR. */
-static __always_inline void dispatch_single_exti(uint32 exti) {
+inline void dispatch_single_exti(uint32 exti) {
     voidArgumentFuncPtr handler = exti_channels[exti].handler;
 
     if (!handler) {
@@ -270,7 +270,7 @@ static __always_inline void dispatch_single_exti(uint32 exti) {
 }
 
 /* Dispatch routine for EXTIs which share an IRQ. */
-static __always_inline void dispatch_extis(uint32 start, uint32 stop) {
+inline void dispatch_extis(uint32 start, uint32 stop) {
     uint32 pr = EXTI_BASE->PR;
     uint32 handled_msk = 0;
     uint32 exti;

--- a/STM32F1/system/libmaple/dma_private.h
+++ b/STM32F1/system/libmaple/dma_private.h
@@ -37,8 +37,8 @@
 /* Wrap this in an ifdef to shut up GCC. (We provide DMA_GET_HANDLER
  * in the series support files, which need dma_irq_handler().) */
 #ifdef DMA_GET_HANDLER
-static __always_inline void dma_irq_handler(dma_dev *dev, dma_tube tube) {
-
+inline void dma_irq_handler(dma_dev *dev, dma_tube tube)
+{
     void (*handler)(void) = DMA_GET_HANDLER(dev, tube);
     if (handler) {
         handler();

--- a/STM32F1/system/libmaple/include/libmaple/libmaple_types.h
+++ b/STM32F1/system/libmaple/include/libmaple/libmaple_types.h
@@ -57,13 +57,6 @@ typedef void (*voidArgumentFuncPtr)(void *);
 #define __packed __attribute__((__packed__))
 #define __deprecated __attribute__((__deprecated__))
 #define __weak __attribute__((weak))
-#ifndef __always_inline
-#if __GNUC_PREREQ__(3, 1) || (defined(__INTEL_COMPILER) && __INTEL_COMPILER >= 800)
-#define	__always_inline	__inline__ __attribute__((__always_inline__))
-#else
-#define	__always_inline
-#endif
-#endif
 #ifndef __unused
 #define __unused __attribute__((unused))
 #endif

--- a/STM32F1/system/libmaple/include/libmaple/nvic.h
+++ b/STM32F1/system/libmaple/include/libmaple/nvic.h
@@ -109,14 +109,14 @@ void nvic_sys_reset();
 /**
  * Enables interrupts and configurable fault handlers (clear PRIMASK).
  */
-static __always_inline void nvic_globalirq_enable() {
+inline void nvic_globalirq_enable() {
     asm volatile("cpsie i");
 }
 
 /**
  * Disable interrupts and configurable fault handlers (set PRIMASK).
  */
-static __always_inline void nvic_globalirq_disable() {
+inline void nvic_globalirq_disable() {
     asm volatile("cpsid i");
 }
 

--- a/STM32F1/system/libmaple/include/libmaple/usb_cdcacm.h
+++ b/STM32F1/system/libmaple/include/libmaple/usb_cdcacm.h
@@ -172,7 +172,7 @@ int usb_cdcacm_get_n_data_bits(void); /* bDataBits */
 
 void usb_cdcacm_set_hooks(unsigned hook_flags, void (*hook)(unsigned, void*));
 
-static __always_inline void usb_cdcacm_remove_hooks(unsigned hook_flags) {
+inline void usb_cdcacm_remove_hooks(unsigned hook_flags) {
     usb_cdcacm_set_hooks(hook_flags, 0);
 }
 

--- a/STM32F1/system/libmaple/stm32f1/include/series/gpio.h
+++ b/STM32F1/system/libmaple/stm32f1/include/series/gpio.h
@@ -486,7 +486,7 @@ typedef exti_num afio_exti_num;
 /**
  * @brief Deprecated. Use exti_select(exti, port) instead.
  */
-static __always_inline void afio_exti_select(exti_num exti, exti_cfg port) {
+inline void afio_exti_select(exti_num exti, exti_cfg port) {
     exti_select(exti, port);
 }
 

--- a/STM32F1/system/libmaple/stm32f1/include/series/spi.h
+++ b/STM32F1/system/libmaple/stm32f1/include/series/spi.h
@@ -75,13 +75,13 @@ extern void spi_config_gpios(struct spi_dev*, uint8,
  * @brief Deprecated. Use spi_config_gpios() instead.
  * @see spi_config_gpios()
  */
-static __always_inline void spi_gpio_cfg(uint8 as_master,
-                                         struct gpio_dev *nss_dev,
-                                         uint8 nss_bit,
-                                         struct gpio_dev *comm_dev,
-                                         uint8 sck_bit,
-                                         uint8 miso_bit,
-                                         uint8 mosi_bit) {
+inline void spi_gpio_cfg(uint8 as_master,
+                         struct gpio_dev *nss_dev,
+                         uint8 nss_bit,
+                         struct gpio_dev *comm_dev,
+                         uint8 sck_bit,
+                         uint8 miso_bit,
+                         uint8 mosi_bit) {
     /* We switched style globally to foo_config_gpios() and always
      * taking a foo_dev* argument (that last bit is the important
      * part) after this function was written.

--- a/STM32F1/system/libmaple/stm32f2/include/series/dma.h
+++ b/STM32F1/system/libmaple/stm32f2/include/series/dma.h
@@ -707,8 +707,7 @@ void dma_set_mem_n_addr(dma_dev *dev, dma_tube tube, int n,
  * @param tube Tube whose memory 0 address to set
  * @param addr Address to use as memory 0
  */
-static __always_inline void
-dma_set_mem0_addr(dma_dev *dev, dma_tube tube, __IO void *addr) {
+inline void dma_set_mem0_addr(dma_dev *dev, dma_tube tube, __IO void *addr) {
     dma_set_mem_n_addr(dev, tube, 0, addr);
 }
 
@@ -720,8 +719,7 @@ dma_set_mem0_addr(dma_dev *dev, dma_tube tube, __IO void *addr) {
  * @param tube Tube whose memory 1 address to set
  * @param addr Address to use as memory 1
  */
-static __always_inline void
-dma_set_mem1_addr(dma_dev *dev, dma_tube tube, __IO void *addr) {
+inline void dma_set_mem1_addr(dma_dev *dev, dma_tube tube, __IO void *addr) {
     dma_set_mem_n_addr(dev, tube, 1, addr);
 }
 
@@ -732,18 +730,18 @@ dma_set_mem_addr(dma_dev *dev, dma_tube tube, __IO void *addr) {
 }
 
 /* SM0AR and SM1AR are treated as though they have the same size */
-static inline dma_xfer_size dma_get_mem_size(dma_dev *dev, dma_tube tube) {
+inline dma_xfer_size dma_get_mem_size(dma_dev *dev, dma_tube tube) {
     return (dma_xfer_size)(dma_tube_regs(dev, tube)->SCR >> 13);
 }
 
-static inline dma_xfer_size dma_get_per_size(dma_dev *dev, dma_tube tube) {
+inline dma_xfer_size dma_get_per_size(dma_dev *dev, dma_tube tube) {
     return (dma_xfer_size)(dma_tube_regs(dev, tube)->SCR >> 11);
 }
 
 void dma_enable_fifo(dma_dev *dev, dma_tube tube);
 void dma_disable_fifo(dma_dev *dev, dma_tube tube);
 
-static __always_inline int dma_is_fifo_enabled(dma_dev *dev, dma_tube tube) {
+inline int dma_is_fifo_enabled(dma_dev *dev, dma_tube tube) {
     return dma_tube_regs(dev, tube)->SFCR & DMA_SFCR_DMDIS;
 }
 

--- a/STM32F1/system/libmaple/timer_private.h
+++ b/STM32F1/system/libmaple/timer_private.h
@@ -121,9 +121,9 @@
  * line may be shared with another timer. For example, the timer 1
  * update interrupt shares an IRQ line with the timer 10 interrupt on
  * STM32F1 (XL-density), STM32F2, and STM32F4. */
-static __always_inline void dispatch_single_irq(timer_dev *dev,
-                                                timer_interrupt_id iid,
-                                                uint32 irq_mask) {
+inline void dispatch_single_irq(timer_dev *dev,
+                                timer_interrupt_id iid,
+                                uint32 irq_mask) {
     timer_bas_reg_map *regs = (dev->regs).bas;
     if (regs->DIER & regs->SR & irq_mask) {
         void (*handler)(void) = dev->handlers[iid];
@@ -145,15 +145,15 @@ static __always_inline void dispatch_single_irq(timer_dev *dev,
         }                                                               \
     } while (0)
 
-static __always_inline void dispatch_adv_brk(timer_dev *dev) {
+inline void dispatch_adv_brk(timer_dev *dev) {
     dispatch_single_irq(dev, TIMER_BREAK_INTERRUPT, TIMER_SR_BIF);
 }
 
-static __always_inline void dispatch_adv_up(timer_dev *dev) {
+inline void dispatch_adv_up(timer_dev *dev) {
     dispatch_single_irq(dev, TIMER_UPDATE_INTERRUPT, TIMER_SR_UIF);
 }
 
-static __always_inline void dispatch_adv_trg_com(timer_dev *dev) {
+inline void dispatch_adv_trg_com(timer_dev *dev) {
     timer_adv_reg_map *regs = (dev->regs).adv;
     uint32 dsr = regs->DIER & regs->SR;
     void (**hs)(void) = dev->handlers;
@@ -168,7 +168,7 @@ static __always_inline void dispatch_adv_trg_com(timer_dev *dev) {
     regs->SR = ~handled;
 }
 
-static __always_inline void dispatch_adv_cc(timer_dev *dev) {
+inline void dispatch_adv_cc(timer_dev *dev) {
     timer_adv_reg_map *regs = (dev->regs).adv;
     uint32 dsr = regs->DIER & regs->SR;
     void (**hs)(void) = dev->handlers;
@@ -182,7 +182,7 @@ static __always_inline void dispatch_adv_cc(timer_dev *dev) {
     regs->SR = ~handled;
 }
 
-static __always_inline void dispatch_general(timer_dev *dev) {
+inline void dispatch_general(timer_dev *dev) {
     timer_gen_reg_map *regs = (dev->regs).gen;
     uint32 dsr = regs->DIER & regs->SR;
     void (**hs)(void) = dev->handlers;
@@ -200,7 +200,7 @@ static __always_inline void dispatch_general(timer_dev *dev) {
 
 /* On F1 (XL-density), F2, and F4, TIM9 and TIM12 are restricted
  * general-purpose timers with update, CC1, CC2, and TRG interrupts. */
-static __always_inline void dispatch_tim_9_12(timer_dev *dev) {
+inline void dispatch_tim_9_12(timer_dev *dev) {
     timer_gen_reg_map *regs = (dev->regs).gen;
     uint32 dsr = regs->DIER & regs->SR;
     void (**hs)(void) = dev->handlers;
@@ -216,7 +216,7 @@ static __always_inline void dispatch_tim_9_12(timer_dev *dev) {
 
 /* On F1 (XL-density), F2, and F4, timers 10, 11, 13, and 14 are
  * restricted general-purpose timers with update and CC1 interrupts. */
-static __always_inline void dispatch_tim_10_11_13_14(timer_dev *dev) {
+inline void dispatch_tim_10_11_13_14(timer_dev *dev) {
     timer_gen_reg_map *regs = (dev->regs).gen;
     uint32 dsr = regs->DIER & regs->SR;
     void (**hs)(void) = dev->handlers;
@@ -228,7 +228,7 @@ static __always_inline void dispatch_tim_10_11_13_14(timer_dev *dev) {
     regs->SR = ~handled;
 }
 
-static __always_inline void dispatch_basic(timer_dev *dev) {
+inline void dispatch_basic(timer_dev *dev) {
     dispatch_single_irq(dev, TIMER_UPDATE_INTERRUPT, TIMER_SR_UIF);
 }
 

--- a/STM32F1/system/libmaple/usart_private.h
+++ b/STM32F1/system/libmaple/usart_private.h
@@ -37,7 +37,7 @@
 #include <libmaple/ring_buffer.h>
 #include <libmaple/usart.h>
 
-static __always_inline void usart_irq(ring_buffer *rb, ring_buffer *wb, usart_reg_map *regs) {
+inline void usart_irq(ring_buffer *rb, ring_buffer *wb, usart_reg_map *regs) {
     /* Handling RXNEIE and TXEIE interrupts. 
      * RXNE signifies availability of a byte in DR.
      *


### PR DESCRIPTION
replaces "static __always_inline" with "inline" directive