### PR TITLE
ARDUINO_ARCH_STM32 should not be defined

### DIFF
--- a/STM32F1/platform.txt
+++ b/STM32F1/platform.txt
@@ -36,7 +36,7 @@ compiler.define=-DARDUINO=
 # this can be overriden in boards.txt
 build.f_cpu=72000000L
 build.mcu=cortex-m3
-build.common_flags=-mthumb  -march=armv7-m -D__STM32F1__ -DARDUINO_ARCH_STM32
+build.common_flags=-mthumb  -march=armv7-m -D__STM32F1__
 build.variant_system_lib=libmaple.a
 ## LED stuff is not really used but is still required in the code
 build.error_led_port=GPIOB


### PR DESCRIPTION
The `ARDUINO_ARCH_{build.arch}` is used to differentiate core.
See: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#working-with-multiple-architectures

Defining  `ARDUINO_ARCH_STM32` will raised several issues on library supporting both cores:
 * `ARDUINO_ARCH_STM32`
 * `ARDUINO_ARCH_STM32F1`

This was introduced here:
https://github.com/rogerclarkmelbourne/Arduino_STM32/commit/2208bcbc5bcff8c25feb3713cdb72f546366957c