### PR TITLE
Avoid C++ demangle to reduce binary size

### DIFF
--- a/STM32F1/cores/maple/cxxabi-compat.cpp
+++ b/STM32F1/cores/maple/cxxabi-compat.cpp
@@ -1,6 +1,19 @@
+#include <cstdlib>
+#include <cstring>
+
 /* We compile with nodefaultlibs, so we need to provide an error
  * handler for an empty pure virtual function */
 extern "C" void __cxa_pure_virtual(void) {
     while(1)
         ;
+}
+
+/* We need to override it in order to avoid bloat binaries
+ * due to using demangling of symbols in backtraces */
+extern "C" char * __cxa_demangle (const char *mangled_name,
+                                  char *output_buffer,
+                                  size_t *length,
+                                  int *status) {
+  strcpy((char*)mangled_name, output_buffer);
+  return output_buffer;
 }


### PR DESCRIPTION
Fix for issue #688

This fix help me reduce Marlin firmware size from 134040 to 103700 bytes (~23%).
So it can fit in 128KB flash.