### PR TITLE
Prepare for audio device class

### DIFF
--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_reg_map.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_reg_map.c
@@ -66,14 +66,14 @@ static void usb_set_ep_rx_count_common(uint32 *rxc, uint16 count) {
         if ((count & 0x1F) == 0) {
             nblocks--;
         }
-        *rxc = (nblocks << 10) | 0x8000;
+        *rxc = (nblocks << 10) | 0x8000 | (count & 0x3FF);
     } else {
         /* use 2-byte memory block size */
         nblocks = count >> 1;
         if ((count & 0x1) != 0) {
             nblocks++;
         }
-        *rxc = nblocks << 10;
+        *rxc = (nblocks << 10) | (count & 0x3FF);
     }
 }
 /*

--- a/STM32F1/system/libmaple/include/libmaple/usb.h
+++ b/STM32F1/system/libmaple/include/libmaple/usb.h
@@ -123,6 +123,7 @@ typedef struct usb_descriptor_string {
 
 #define USB_EP_TYPE_INTERRUPT             0x03
 #define USB_EP_TYPE_BULK                  0x02
+#define USB_EP_TYPE_ISO                   0x01
 
 #define USB_DESCRIPTOR_ENDPOINT_IN        0x80
 #define USB_DESCRIPTOR_ENDPOINT_OUT       0x00


### PR DESCRIPTION
A couple of libmaple additions to prepare for usb composite audio device class. Allows double buffered isochronous IN endpoints to function correctly. Fixes #687.