### PR TITLE
Fix I2C master 2-byte read case

### DIFF
--- a/STM32F1/cores/maple/libmaple/i2c.c
+++ b/STM32F1/cores/maple/libmaple/i2c.c
@@ -491,9 +491,9 @@ void _i2c_irq_handler(i2c_dev *dev) {
                             sr2 = dev->regs->SR2;                   // Clear ADDR bit
                             dev->regs->CR1 = (cr1 |= I2C_CR1_STOP); // Stop after last byte
                         } else if (todo == 2) {
-                            dev->regs->CR1 = (cr1 &= ~I2C_CR1_ACK); // Disable ACK
                             dev->regs->CR1 = (cr1 |= I2C_CR1_POS);  // Enable POS
                             sr2 = dev->regs->SR2;                   // Clear ADDR bit
+                            dev->regs->CR1 = (cr1 &= ~I2C_CR1_ACK); // Disable ACK
                         } else {
                             dev->regs->CR1 = (cr1 |= I2C_CR1_ACK);  // Enable ACK
                             sr2 = dev->regs->SR2;                   // Clear ADDR bit


### PR DESCRIPTION
This fixes #704 

The I2C master mode 2-byte read was incorrectly NAKing prematurely causing the second byte of all 2-byte reads to be returned as `FF`.

As per the ST datasheet for the CR1 register when using read Method 2, it's very important to clear the ACK bit AFTER clearing the ADDR (not before the ADDR is cleared!):

>Note: The POS bit is used when the procedure for reception of 2 bytes (see Method 2:
transfer sequence diagram for master receiver when N=2) is followed. It must be
configured before data reception starts. In this case, to NACK the 2nd byte, the ACK bit
must be cleared just after ADDR is cleared. To check the 2nd byte as PEC, the PEC bit
must be set during the ADDR stretch event after configuring the POS bit.

This PR swaps the clearing of the ACK-bit to after clearing the ADDR via the read of SR2.

Thanks @bergos for finding this issue.

@TheKikGen if you get a chance, please pull this commit and give your I2C code a quick check.  Apparently neither you nor I had done any 2-byte Master read sequences where the second byte was supposed to be something other than `FF`.  This should fix that.  This change should only affect the 2-byte master read path.
