### PR TITLE
Print updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ other/maple-bootloader/*~
 *.1
 platform.local.txt
 boards.local.txt
+/.vs/*

--- a/STM32F1/cores/maple/Print.cpp
+++ b/STM32F1/cores/maple/Print.cpp
@@ -51,11 +51,10 @@ size_t Print::write(const char *str) {
 	return write((const uint8_t *)str, strlen(str));
 }
 
-size_t Print::write(const void *buffer, uint32 size) {
+size_t Print::write(const uint8_t *buffer, size_t size) {
 	size_t n = 0;
-    uint8 *ch = (uint8*)buffer;
     while (size--) {
-        write(*ch++);
+        write(*buffer++);
         n++;
     }
 	return n;

--- a/STM32F1/cores/maple/Print.cpp
+++ b/STM32F1/cores/maple/Print.cpp
@@ -51,12 +51,13 @@ size_t Print::write(const char *str) {
 	return write((const uint8_t *)str, strlen(str));
 }
 
-size_t Print::write(const uint8_t *buffer, size_t size) {
+size_t Print::write(const void* buffer, uint32 size) {
 	size_t n = 0;
-    while (size--) {
-        write(*buffer++);
-        n++;
-    }
+	uint8* ch = (uint8*)buffer;
+	while (size--) {
+		write(*ch++);
+		n++;
+	}
 	return n;
 }
 

--- a/STM32F1/cores/maple/Print.h
+++ b/STM32F1/cores/maple/Print.h
@@ -36,9 +36,13 @@ enum {
 
 class Print {
 public:
-    virtual size_t write(uint8 ch) = 0;
+    virtual size_t write(uint8_t ch) = 0;
     virtual size_t write(const char *str);
-    virtual size_t write(const void *buf, uint32 len);
+    virtual size_t write(const uint8_t *buf, size_t len);
+	size_t write(const char* buffer, size_t size)
+	{
+		return write((const uint8_t*)buffer, size);
+	}
 	
 	size_t print(const String &);
     size_t print(char);

--- a/STM32F1/cores/maple/Print.h
+++ b/STM32F1/cores/maple/Print.h
@@ -36,15 +36,15 @@ enum {
 
 class Print {
 public:
-    virtual size_t write(uint8_t ch) = 0;
+    virtual size_t write(uint8 ch) = 0;
     virtual size_t write(const char *str);
-    virtual size_t write(const uint8_t *buf, size_t len);
-	virtual size_t write(const void *buf, uint32 len) {
-		return write((const uint8_t *) buf, (size_t) len);
+	virtual size_t write(const void* buf, uint32 len)
+    virtual size_t write(const uint8_t *buffer, size_t size){
+		return write((const void*) buffer, (uint32)size);
 	}
 	size_t write(const char *buffer, size_t size)
 	{
-		return write((const uint8_t *) buffer, size);
+		return write((const void *) buffer, (uint32) size);
 	}
 	
 	size_t print(const String &);

--- a/STM32F1/cores/maple/Print.h
+++ b/STM32F1/cores/maple/Print.h
@@ -39,9 +39,12 @@ public:
     virtual size_t write(uint8_t ch) = 0;
     virtual size_t write(const char *str);
     virtual size_t write(const uint8_t *buf, size_t len);
-	size_t write(const char* buffer, size_t size)
+	virtual size_t write(const void *buf, uint32 len) {
+		return write((const uint8_t *) buf, (size_t) len);
+	}
+	size_t write(const char *buffer, size_t size)
 	{
-		return write((const uint8_t*)buffer, size);
+		return write((const uint8_t *) buffer, size);
 	}
 	
 	size_t print(const String &);


### PR DESCRIPTION
Make write(buffer, size) compatible with standard arduino convention.

This fixes some problems that some libraries not overloading function while passing stream or print class (e.g. standard ethernet library). With this fix printing a web page changes form 1sec to 40msec.

Added /.vs/ in gitignore for visual studio users like me...