### PR TITLE
I2C Master should send a STOP when receiving NACK error (SR1_AF)

### DIFF
--- a/STM32F1/cores/maple/libmaple/i2c.c
+++ b/STM32F1/cores/maple/libmaple/i2c.c
@@ -782,6 +782,11 @@ void _i2c_irq_error_handler(i2c_dev *dev) {
             dev->state = I2C_STATE_IDLE;
             return;
         }
+    } else {
+        // Master should send a STOP on NACK:
+        if (sr1 & I2C_SR1_AF) {
+            dev->regs->CR1 |= I2C_CR1_STOP;
+        }
     }
 
     /* Catch any other strange errors while in slave mode.


### PR DESCRIPTION
This is the PR that fixes #638 and is equivalent to the bundle I posted there at [fix_i2cmaster_StopOnNACK.zip](https://github.com/rogerclarkmelbourne/Arduino_STM32/files/3907857/fix_i2cmaster_StopOnNACK.zip)

The NACK should only be sent by the master and the only one missing was the error case in the this interrupt handler for the AF (acknowledge failed) case.  The other stop conditions are handled by the main interrupt routine.

Adding a stop to all paths would be wrong because it can actually cause a restart condition with the I2C if the previous one had finished.
