### PR TITLE
Add a way to remap I2C1 pins after construction of standard Wire instance

### DIFF
--- a/STM32F1/libraries/Wire/Wire.cpp
+++ b/STM32F1/libraries/Wire/Wire.cpp
@@ -102,4 +102,12 @@ void TwoWire::setClock(uint32_t frequencyHz)
 	}
 }
 
+void TwoWire::setDevFlags(uint8 df) {
+    dev_flags = df;
+}
+
+uint8 TwoWire::getDevFlags(void) {
+    return dev_flags;
+}
+
 TwoWire Wire(1);

--- a/STM32F1/libraries/Wire/Wire.h
+++ b/STM32F1/libraries/Wire/Wire.h
@@ -72,6 +72,13 @@ public:
 	* Sets the hardware I2C clock
 	*/
 	void setClock(uint32_t frequencyHz);
+	
+	/*
+	* Useful to remap I2C1 to alternate pins PB8, PB9
+	* after construction by adding flag I2C_REMAP
+	*/
+	void setDevFlags(uint8 dev_flags);
+	uint8 getDevFlags(void);
     /*
      * Disables the I2C device and remove the device address.
      */


### PR DESCRIPTION
Normally there is no way to edit the dev_flags variable after Wire has been constructed. It is sometimes helpful to do so though. Example: u8g2 uses the builtin Wire instance to communicate with I2C displays which is normally set to the standard pins.

Using the added functions from this PR it is possible to:

```
//during setup():
uint8_t df = Wire.getDevFlags();
df |= I2C_REMAP;
Wire.setDevFlags(df);
```

After that u8g2 will nicely communicate with an I2C display connected to the alternate pins.