### PR TITLE
support for fake stm32f103c8t6

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -358,6 +358,13 @@ genericSTM32F103C.menu.device_variant.STM32F103CB.build.ldscript=ld/jtag.ld
 genericSTM32F103C.menu.device_variant.STM32F103CB.upload.maximum_size=131072
 genericSTM32F103C.menu.device_variant.STM32F103CB.upload.maximum_data_size=20480
 
+## STM32F103FEBK6 (fake STM32F103C8T6) -------------------------
+genericSTM32F103C.menu.device_variant.STM32F103C6=STM32F103FEBK6 (10k RAM. 32k Flash)
+genericSTM32F103C.menu.device_variant.STM32F103C6.build.cpu_flags=-DMCU_STM32F103C8
+genericSTM32F103C.menu.device_variant.STM32F103C6.build.ldscript=ld/jtag_k6.ld
+genericSTM32F103C.menu.device_variant.STM32F103C6.upload.maximum_size=32768
+genericSTM32F103C.menu.device_variant.STM32F103C6.upload.maximum_data_size=10240
+
 #---------------------------- UPLOAD METHODS ---------------------------
 
 genericSTM32F103C.menu.upload_method.DFUUploadMethod=STM32duino bootloader

--- a/STM32F1/variants/generic_stm32f103c/ld/jtag_k6.ld
+++ b/STM32F1/variants/generic_stm32f103c/ld/jtag_k6.ld
@@ -1,0 +1,36 @@
+/*
+ * libmaple linker script for "JTAG" builds.
+ *
+ * A "JTAG" build puts .text (and .rodata) in Flash, and
+ * .data/.bss/heap (of course) in SRAM, but links starting at the
+ * Flash and SRAM starting addresses (0x08000000 and 0x20000000
+ * respectively). This will wipe out a Maple bootloader if there's one
+ * on the board, so only use this if you know what you're doing.
+ *
+ * Of course, a "JTAG" build is perfectly usable for upload over SWD,
+ * the system memory bootloader, etc. The name is just a historical
+ * artifact.
+ */
+
+/*
+ * This pulls in the appropriate MEMORY declaration from the right
+ * subdirectory of stm32/mem/ (the environment must call ld with the
+ * right include directory flags to make this happen). Boards can also
+ * use this file to use any of libmaple's memory-related hooks (like
+ * where the heap should live).
+ */
+
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 10K
+  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 32K
+}
+
+/* Provide memory region aliases for common.inc */
+REGION_ALIAS("REGION_TEXT", rom);
+REGION_ALIAS("REGION_DATA", ram);
+REGION_ALIAS("REGION_BSS", ram);
+REGION_ALIAS("REGION_RODATA", rom);
+
+/* Let common.inc handle the real work. */
+INCLUDE common.inc


### PR DESCRIPTION
This PR adds support for the 32K flash/10K ram blue pill boards:

 https://embeddedtronicsblog.wordpress.com/2018/12/29/fake-stm32-blue-pill-boards/

The current bootloader doesn't work with these, but serial upload works fine.