### PR TITLE
Added digitalPinToInterrupt macro for STM32F4

### DIFF
--- a/STM32F4/cores/maple/wirish.h
+++ b/STM32F4/cores/maple/wirish.h
@@ -67,6 +67,8 @@
                                                    bitClear(value, bit))
 #define bit(b)                         (1UL << (b))
 
+#define digitalPinToInterrupt(pin)     (pin)
+
 typedef uint8 boolean;
 typedef uint8 byte;
 


### PR DESCRIPTION
Hi,

digitalPinToInterrupt macro seems to be missing for STM32F4, which causes an issue if some Arduino library happens to be using it ;)

I added it the same way it was done on STM32F1.