### PR TITLE
F4: updates in adc.h and adc.c

### DIFF
--- a/STM32F4/cores/maple/libmaple/adc.c
+++ b/STM32F4/cores/maple/libmaple/adc.c
@@ -74,6 +74,7 @@ const adc_dev adc3 = {
     .handler_p = &adc3Handlers
 };
 
+
 adc_common_reg_map* const ADC_COMMON = ADC_COMMON_BASE;
 
 /**
@@ -148,6 +149,12 @@ void adc_awd_enable_irq(const adc_dev * dev)
     nvic_irq_enable(NVIC_ADC_1_2_3);
 }
 
+void adc_ovr_enable_irq(const adc_dev* dev)
+{
+    dev->regs->CR1 |= ADC_CR1_OVRIE;
+    //nvic_irq_enable(NVIC_ADC_1_2_3);
+}
+
 /*
     attach interrupt functionality for ADC
     use ADC_EOC, ADC_JEOC, ADC_AWD
@@ -160,7 +167,12 @@ void adc_attach_interrupt(const adc_dev *dev,
     if (irq_id<ADC_LAST_IRQ_ID)
     {
         (*(dev->handler_p))[irq_id] = handler;
-        adc_enable_irq(dev);
+        if(irq_id == ADC_EOC)
+        	adc_enable_irq(dev);
+        else if (irq_id == ADC_AWD)
+        	adc_awd_enable_irq(dev);
+        else if (irq_id == ADC_OVR)
+        	adc_ovr_enable_irq(dev);
     }
 }
 
@@ -181,6 +193,16 @@ void adc_foreach(void (*fn)(const adc_dev*))
     fn(ADC1);
     fn(ADC2);
     fn(ADC3);
+}
+
+/*
+ *  @param pre, setup the ADC prescaler to one of PCLK /2, /4, /6, /8
+ *         the templates per adc_prescaler enum
+ */
+void adc_set_prescaler(adc_prescaler pre) {
+
+	ADC_COMMON->CCR &= ~ ADC_CCR_ADCPRE;
+	ADC_COMMON->CCR |= ((pre & 3U) << ADC_CCR_ADCPRE_SHIFT);
 }
 
 /**
@@ -303,6 +325,15 @@ void adc_irq_handler(const adc_dev * dev)
             handler();
         }
     }
+    //ADC overrun interrupt
+    if (dev->regs->SR & ADC_SR_OVR) {
+        dev->regs->SR = ~ADC_SR_OVR;
+        voidFuncPtr handler = (*(dev->handler_p))[ADC_OVR];
+        if (handler) {
+            handler();
+        }
+    }
+
 }
 
 void __irq_adc()

--- a/STM32F4/cores/maple/libmaple/adc.c
+++ b/STM32F4/cores/maple/libmaple/adc.c
@@ -152,7 +152,7 @@ void adc_awd_enable_irq(const adc_dev * dev)
 void adc_ovr_enable_irq(const adc_dev* dev)
 {
     dev->regs->CR1 |= ADC_CR1_OVRIE;
-    //nvic_irq_enable(NVIC_ADC_1_2_3);
+    nvic_irq_enable(NVIC_ADC_1_2_3);
 }
 
 /*

--- a/STM32F4/libraries/STM32F4_ADC/examples/PR784F4AdcTest/PR784F4AdcTest.ino
+++ b/STM32F4/libraries/STM32F4_ADC/examples/PR784F4AdcTest/PR784F4AdcTest.ino
@@ -1,0 +1,191 @@
+#include <Arduino.h>
+
+#define LEDON 0
+#define LEDOFF 1
+
+bool adc_overrun = false;
+bool awd_triggered = false;
+
+void overrun_handler();
+void awd_handler();
+void setADCprescaler();
+void toggle_awd();
+float temp_convert(int data);
+void setup_awd(uint16_t data);
+
+void setup() {
+
+  //note this turns 'on' the led, as active low is assumed
+  pinMode(LED_BUILTIN, OUTPUT);
+  Serial.begin(); // USB serial
+
+  while(!Serial); // wait for terminal to connect
+
+  // setup the ADC prescaler
+  setADCprescaler();
+  // use a long sample time - measure temperature
+  // if we assume pclk = 84 mhz, prescaler = 4, so adcclock = 84 / 4 = 21 mhz
+  // from rm0009
+  // Tconv = sample time + 12 cycles = 480 + 12 = 492 cycles ~ 42 k samples per sec !
+  adc_set_sampling_time(ADC1, ADC_SMPR_480);
+  // use single mode
+  adc_clear_continuous(ADC1);
+
+  //enable temp sensor
+  adc_enable_tsvref();
+
+  //setup the AWD to test threshold triggering
+  //in this case it is using the AWD to detect high (i.e. max) temperatures
+  //delay(1);
+  //uint16_t data = adc_read(ADC1, 18);
+  uint16_t data = 800; //set a low threshold so that awd would trigger
+  setup_awd(data);
+  adc_awd_enable_channel(ADC1, 18);
+  Serial.print("Temp (C):");
+  Serial.println(temp_convert(data));
+
+  // attach overrun interrupt, this is for the overrun interrupt test
+  adc_attach_interrupt(ADC1, ADC_OVR, overrun_handler);
+  ADC1->regs->CR2 |= ADC_CR2_EOCS;
+
+  // attach awd interrupt, this is for awd tests
+  adc_attach_interrupt(ADC1, ADC_AWD, awd_handler);
+
+  digitalWrite(LED_BUILTIN, LEDOFF);
+  Serial.println("enter 'w' to toggle AWD");
+  adc_awd_enable(ADC1);
+}
+
+void loop() {
+
+  if(Serial.available()) {
+    uint8_t c = Serial.read();
+    if(c == 'w')
+      toggle_awd();
+  }
+
+  if(adc_overrun) {
+    Serial.println("ADC overrun!");
+    digitalWrite(LED_BUILTIN, LEDON);
+    delay(100);
+    digitalWrite(LED_BUILTIN, LEDOFF);
+    delay(100);
+    adc_overrun = false;
+  }
+
+  // this is the call to read adc voltages.
+  // uint18_t data = adc_read(ADC1, 18);
+  // as both awd and adc is being used, when awd triggers
+  // AWD is set but EOC may not be set, hence adc_read() is not used
+  // and we'd need to do some additional handling for AWD trigger
+    adc_start_single_convert(ADC1, 18);
+    while (!adc_is_end_of_convert(ADC1)) {
+      if(awd_triggered) {
+        //if awd is triggered we disable awd and read
+        //the adc again
+        adc_awd_disable(ADC1);
+        adc_start_single_convert(ADC1, 18);
+      }
+      //wait for systick, delay(1)
+      asm("wfi");
+    }
+    uint16_t data = adc_get_data(ADC1);
+
+  // uncomment next 3 statements to test overrun
+    //ADC1->regs->CR2 |= ADC_CR2_SWSTART;
+  //delay(1);
+  //ADC1->regs->CR2 |= ADC_CR2_SWSTART;
+
+  if(awd_triggered) {
+    Serial.println("New High Temp");
+    setup_awd(data);
+    adc_awd_enable(ADC1);
+    awd_triggered = false;
+  }
+
+  Serial.print("Temp (C):");
+  Serial.println(temp_convert(data));
+
+  // sleep 1-2s wait for systick, not accurate
+  for(int i=0; i<2000; i++) asm("wfi");
+}
+
+void overrun_handler() {
+  adc_overrun = true;
+}
+
+void awd_handler() {
+  ADC1->regs->SR &= ~ ADC_SR_AWD;
+  awd_triggered = true;
+}
+
+void setup_awd(uint16_t data) {
+  adc_awd_set_high_limit(ADC1, data);
+  adc_awd_set_low_limit(ADC1, 0);
+  ADC1->regs->SR &= ~ ADC_SR_AWD;
+}
+
+void toggle_awd() {
+  uint8_t awden = bb_peri_get_bit(&(ADC1->regs->CR1), ADC_CR1_AWDEN_BIT);
+  if(awden) {
+    adc_awd_disable(ADC1);
+    Serial.println("AWD disabled");
+  } else {
+    adc_awd_enable(ADC1);
+    Serial.println("AWD enabled");
+  }
+
+}
+
+void setADCprescaler() {
+  // in datasheet ADC max freq, e.g. F401/F411/F405/F407/F429
+  const int ADC_MAX_MHZ = 36;
+
+  // note CLOCK_SPEED_MHZ is defined in the variant board specific .h file
+  //      to get a 2.4 Msps speeds for each ADC a cpu clock speeds of 144 mhz or 72 mhz needs to be used
+  //      so that a pclk2 runs at 72 mhz and adc prescaler = 2 so max adc clock = 36 mhz can be achieved
+  int pclk2 = CLOCK_SPEED_MHZ > 100 ? CLOCK_SPEED_MHZ / 2 : CLOCK_SPEED_MHZ;
+
+  int prescaler_sel = 1;
+  // find the pre-scaler divisor that gives adc clock frequency less than or
+  // equal to ADC_MAX_MHZ
+  while( pclk2 / ( prescaler_sel * 2) > ADC_MAX_MHZ )
+    prescaler_sel++;
+
+  Serial.print("Setting ADC clock to: ");
+  Serial.print(pclk2 / (prescaler_sel * 2));
+  Serial.println(" Mhz");
+
+  adc_prescaler prescaler;
+  switch (prescaler_sel * 2) {
+  case 2:
+    prescaler = ADC_PRE_PCLK2_DIV_2;
+    break;
+  case 4:
+    prescaler = ADC_PRE_PCLK2_DIV_4;
+    break;
+  case 6:
+    prescaler = ADC_PRE_PCLK2_DIV_6;
+    break;
+  case 8:
+    prescaler = ADC_PRE_PCLK2_DIV_8;
+    break;
+  default:
+    // we make an assumption pclk2 = 84mhz, so if 'all else fails'
+    // we make the adc clock run at 21 mhz
+    prescaler = ADC_PRE_PCLK2_DIV_4;
+  }
+
+  adc_set_prescaler(prescaler);
+}
+
+
+float temp_convert(int data) {
+
+    const float averageSlope = 2.5; // mV/°C
+    const float v25 = 760.0; // [mV]
+
+    float vSense = (3300.0*data)/4096; // mV
+    float temperature = ((vSense-v25)/averageSlope) + 25.0;
+    return temperature;
+}

--- a/STM32F4/libraries/STM32F4_ADC/examples/PR784F4AdcTest/readme.md
+++ b/STM32F4/libraries/STM32F4_ADC/examples/PR784F4AdcTest/readme.md
@@ -1,0 +1,65 @@
+## This sketch is a test for some functions added to the F4 core in adc.h and adc.c added in PR 784
+
+ref: [PR 784 F4: updates in adc.h and adc.c #784](https://github.com/rogerclarkmelbourne/Arduino_STM32/pull/784)
+
+### How to run this sketch
+
+Build the sketch against the F4 libmaple core and install it on the board. The boards that should work 
+may include STM32F4xx( STM32F401, STM32F411, STM32F405, STM32F407, STM32F427, STM32F429) boards.
+
+Connect to the serial terminal and it should start printing the core temperature.
+it responds to a single char command 'w' which toggles the analog watch dog on and off.
+
+### * ADC_PRESCALER
+
+The function adc_set_prescaler() has been added in adc.h, adc.c
+adc.h
+```
+/**
+ * @brief STM32F1/F4 ADC prescalers, as divisors of PCLK2.
+ */
+typedef enum adc_prescaler {
+    /** PCLK2 divided by 2 */
+    ADC_PRE_PCLK2_DIV_2 = 0,
+    /** PCLK2 divided by 4 */
+    ADC_PRE_PCLK2_DIV_4 = 1,
+    /** PCLK2 divided by 6 */
+    ADC_PRE_PCLK2_DIV_6 = 2,
+    /** PCLK2 divided by 8 */
+    ADC_PRE_PCLK2_DIV_8 = 3,
+} adc_prescaler;
+
+void adc_set_prescaler(adc_prescaler pre);
+```
+### How is this tested in the sketch
+
+The function in the sketch void ``setADCprescaler()`` selects a prescalar to get the highest
+adc clocks based on the define CLOCK_SPEED_MHZ defined in the variant specific include file.
+
+ 
+### * additional fixes and support for overrun interrupt and awd interrupt, added adc_awd_disable()
+
+Updated codes in ``adc_attach_interrupt()`` and ``adc_irq_handler()`` to support overrun interrupt and awd
+(analog watch dog) interrupt.
+added missing function ``adc_awd_disable()`` in adc.h, adc.c
+
+ 
+### How is this tested in the sketch
+
+This sketch sets up an analog watch dog to test an upper threshold voltage. in this case it reads 
+the internal temperature sensor and triggers when a higher temperature is detected
+
+### How is the overrun interrupt tested in the sketch
+
+To test the overrun interrupt you need to uncomment the statements in ``loop()``:
+```
+    }
+    uint16_t data = adc_get_data(ADC1);
+    
+    // uncomment next 3 statements to test overrun
+    ADC1->regs->CR2 |= ADC_CR2_SWSTART;
+    delay(1);
+    ADC1->regs->CR2 |= ADC_CR2_SWSTART;
+```	
+The sketch would respond with printing a "ADC Overrun!" and blinks the led. 
+


### PR DESCRIPTION
- ADC1, ADC2, ADC3 fixup for invalid conversion from const errors

initially i'm running into some errors: invalid conversion from
'const adc_dev*' while using ADC1, ADC2, ADC3
```
 extern const adc_dev adc1;
 extern const adc_dev adc2;
 extern const adc_dev adc3;
 
 #define ADC1 (&adc1)
 #define ADC2 (&adc2)
 #define ADC3 (&adc3)
```
those errors are resolved by defining them as follows

```
 extern const adc_dev adc1;
 extern const adc_dev adc2;
 extern const adc_dev adc3;

 #define ADC1 ((adc_dev*) &adc1)
 #define ADC2 ((adc_dev*) &adc2)
 #define ADC3 ((adc_dev*) &adc3)
```

- add adc_prescaler
this is modeled after the same function in the F1 core, the macro symbols are same as well. this would make it more 'compatible' for those writing codes that may possibly be used in both F1 and F4 sets.

adc.h
```
/**
 * @brief STM32F1/F4 ADC prescalers, as divisors of PCLK2.
 */
typedef enum adc_prescaler {
    /** PCLK2 divided by 2 */
    ADC_PRE_PCLK2_DIV_2 = 0,
    /** PCLK2 divided by 4 */
    ADC_PRE_PCLK2_DIV_4 = 1,
    /** PCLK2 divided by 6 */
    ADC_PRE_PCLK2_DIV_6 = 2,
    /** PCLK2 divided by 8 */
    ADC_PRE_PCLK2_DIV_8 = 3,
} adc_prescaler;

void adc_set_prescaler(adc_prescaler pre);
```
adc.c
```
/*
 *  @param pre, setup the ADC prescaler to one of PCLK /2, /4, /6, /8
 *         the templates per adc_prescaler enum
 */
void adc_set_prescaler(adc_prescaler pre) {

	ADC_COMMON->CCR &= ~ ADC_CCR_ADCPRE;
	ADC_COMMON->CCR |= ((pre & 3U) << ADC_CCR_ADCPRE_SHIFT);
}
```

- add static inline void adc_awd_disable()

adc.h
```
static inline void adc_awd_disable(const adc_dev * dev)
{
	dev->regs->CR1 &= ~ADC_CR1_AWDEN;
}
```

- add ADC overrun interrupt support,
add missing adc_awd_enable_irq() when setting up adc_awd irq handler

adc.h
```
//Added by bubulindo - Interrupt ID's for ADC
typedef enum {
    ADC_EOC,     // End Of Conversion interrupt.
    ADC_AWD ,    // Analog WatchDog interrupt
    ADC_JEOC,    // Injected End Of Conversion interrupt.
    ADC_OVR,	 // overrun interrupt
    ADC_LAST_IRQ_ID
} adc_irq_id;

void adc_ovr_enable_irq(const adc_dev* dev);
```

adc.c
```
void adc_ovr_enable_irq(const adc_dev* dev)
{
    dev->regs->CR1 |= ADC_CR1_OVRIE;
    //nvic_irq_enable(NVIC_ADC_1_2_3);
}

void adc_attach_interrupt(const adc_dev *dev,
                            adc_irq_id irq_id,
                            voidFuncPtr handler)
{
    if (irq_id<ADC_LAST_IRQ_ID)
    {
        (*(dev->handler_p))[irq_id] = handler;
        if(irq_id == ADC_EOC)
        	adc_enable_irq(dev);
        else if (irq_id == ADC_AWD)
        	adc_awd_enable_irq(dev);
        else if (irq_id == ADC_OVR)
        	adc_ovr_enable_irq(dev);
    }
}

/*
    ADC IRQ handler.
    added by bubulindo
*/
void adc_irq_handler(const adc_dev * dev)
{
    //End Of Conversion
    if (dev->regs->SR & ADC_SR_EOC) {
        dev->regs->SR = ~ADC_SR_EOC;
        voidFuncPtr handler = (*(dev->handler_p))[ADC_EOC];
        if (handler) {
            handler();
        }
    }
    //Injected End Of Conversion
    if (dev->regs->SR & ADC_SR_JEOC) {
        dev->regs->SR = ~ADC_SR_JEOC;
        voidFuncPtr handler = (*(dev->handler_p))[ADC_JEOC];
        if (handler) {
            handler();
        }
    }
    //Analog Watchdog
    if (dev->regs->SR & ADC_SR_AWD) {
        dev->regs->SR = ~ADC_SR_AWD;
        voidFuncPtr handler = (*(dev->handler_p))[ADC_AWD];
        if (handler) {
            handler();
        }
    }

    //ADC overrun interrupt
    if (dev->regs->SR & ADC_SR_OVR) {
        dev->regs->SR = ~ADC_SR_OVR;
        voidFuncPtr handler = (*(dev->handler_p))[ADC_OVR];
        if (handler) {
            handler();
        }
    }

}
```