### PR TITLE
New toolchain: Updated "platform.txt"  to use the xpack gcc 9…

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -6,6 +6,7 @@ menu.upload_method=Upload method
 menu.cpu_speed=CPU Speed(MHz)
 menu.opt=Optimize
 menu.rtlib=C Runtime Library
+menu.tchain=Toolchain
 
 ##############################################################
 mapleMini.name=Maple Mini
@@ -78,6 +79,12 @@ mapleMini.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_f
 mapleMini.menu.rtlib.full=Newlib Standard
 mapleMini.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+genericSTM32F103C.menu.tchain.xpack=xPack GCC 9 (default)
+genericSTM32F103C.menu.tchain.eabi=Arm none eabi GCC
+genericSTM32F103C.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+genericSTM32F103C.menu.tchain.eabi.build.flags.ldspecs=
+
 ##############################################################
 maple.name=Maple (Rev 3)
 
@@ -139,6 +146,12 @@ maple.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 maple.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 maple.menu.rtlib.full=Newlib Standard
 maple.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+maple.menu.tchain.xpack=xPack GCC 9 (default)
+maple.menu.tchain.eabi=Arm none eabi GCC
+maple.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+maple.menu.tchain.eabi.build.flags.ldspecs=
 
 ##############################################################
 mapleRET6.name=Maple (RET6)
@@ -203,6 +216,12 @@ mapleRET6.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 mapleRET6.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 mapleRET6.menu.rtlib.full=Newlib Standard
 mapleRET6.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+mapleRET6.menu.tchain.xpack=xPack GCC 9 (default)
+mapleRET6.menu.tchain.eabi=Arm none eabi GCC
+mapleRET6.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+mapleRET6.menu.tchain.eabi.build.flags.ldspecs=
 
 ##############################################################
 
@@ -275,6 +294,12 @@ microduino32_flash.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u 
 microduino32_flash.menu.rtlib.full=Newlib Standard
 microduino32_flash.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+microduino32_flash.menu.tchain.xpack=xPack GCC 9 (default)
+microduino32_flash.menu.tchain.eabi=Arm none eabi GCC
+microduino32_flash.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+microduino32_flash.menu.tchain.eabi.build.flags.ldspecs=
+
 ##############################################################
 nucleo_f103rb.name=STM Nucleo F103RB (STLink)
 
@@ -341,6 +366,12 @@ nucleo_f103rb.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 nucleo_f103rb.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 nucleo_f103rb.menu.rtlib.full=Newlib Standard
 nucleo_f103rb.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+nucleo_f103rb.menu.tchain.xpack=xPack GCC 9 (default)
+nucleo_f103rb.menu.tchain.eabi=Arm none eabi GCC
+nucleo_f103rb.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+nucleo_f103rb.menu.tchain.eabi.build.flags.ldspecs=
 
 ###################### Generic STM32F103C ########################################
 
@@ -450,6 +481,12 @@ genericSTM32F103C.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _
 genericSTM32F103C.menu.rtlib.full=Newlib Standard
 genericSTM32F103C.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+genericSTM32F103C.menu.tchain.xpack=xPack GCC 9 (default)
+genericSTM32F103C.menu.tchain.eabi=Arm none eabi GCC
+genericSTM32F103C.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+genericSTM32F103C.menu.tchain.eabi.build.flags.ldspecs=
+
 ###################### Generic STM32F103C6 ########################################
 
 genericSTM32F103C6.name=Generic STM32F103C6/fake STM32F103C8
@@ -548,6 +585,12 @@ genericSTM32F103C6.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 genericSTM32F103C6.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 genericSTM32F103C6.menu.rtlib.full=Newlib Standard
 genericSTM32F103C6.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+genericSTM32F103C6.menu.tchain.xpack=xPack GCC 9 (default)
+genericSTM32F103C6.menu.tchain.eabi=Arm none eabi GCC
+genericSTM32F103C6.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+genericSTM32F103C6.menu.tchain.eabi.build.flags.ldspecs=
 
 ########################### Generic STM32F103R ###########################
 
@@ -661,6 +704,12 @@ genericSTM32F103R.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _
 genericSTM32F103R.menu.rtlib.full=Newlib Standard
 genericSTM32F103R.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+genericSTM32F103R.menu.tchain.xpack=xPack GCC 9 (default)
+genericSTM32F103R.menu.tchain.eabi=Arm none eabi GCC
+genericSTM32F103R.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+genericSTM32F103R.menu.tchain.eabi.build.flags.ldspecs=
+
 ###################### Generic STM32F103T ########################################
 
 genericSTM32F103T.name=Generic STM32F103T series
@@ -755,6 +804,12 @@ genericSTM32F103T.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 genericSTM32F103T.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 genericSTM32F103T.menu.rtlib.full=Newlib Standard
 genericSTM32F103T.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+genericSTM32F103T.menu.tchain.xpack=xPack GCC 9 (default)
+genericSTM32F103T.menu.tchain.eabi=Arm none eabi GCC
+genericSTM32F103T.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+genericSTM32F103T.menu.tchain.eabi.build.flags.ldspecs=
 
 ########################### Generic STM32F103V ###########################
 
@@ -868,6 +923,12 @@ genericSTM32F103V.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _
 genericSTM32F103V.menu.rtlib.full=Newlib Standard
 genericSTM32F103V.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+genericSTM32F103V.menu.tchain.xpack=xPack GCC 9 (default)
+genericSTM32F103V.menu.tchain.eabi=Arm none eabi GCC
+genericSTM32F103V.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+genericSTM32F103V.menu.tchain.eabi.build.flags.ldspecs=
+
 ########################### Generic STM32F103Z ###########################
 
 genericSTM32F103Z.name=Generic STM32F103Z series
@@ -967,6 +1028,12 @@ genericSTM32F103Z.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _
 genericSTM32F103Z.menu.rtlib.full=Newlib Standard
 genericSTM32F103Z.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+genericSTM32F103Z.menu.tchain.xpack=xPack GCC 9 (default)
+genericSTM32F103Z.menu.tchain.eabi=Arm none eabi GCC
+genericSTM32F103Z.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+genericSTM32F103Z.menu.tchain.eabi.build.flags.ldspecs=
+
 ###################### HYTiny STM32F103T ########################################
 
 hytiny-stm32f103t.name=HYTiny STM32F103TB
@@ -1058,6 +1125,12 @@ hytiny-stm32f103t.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _
 hytiny-stm32f103t.menu.rtlib.full=Newlib Standard
 hytiny-stm32f103t.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+hytiny-stm32f103t.menu.tchain.xpack=xPack GCC 9 (default)
+hytiny-stm32f103t.menu.tchain.eabi=Arm none eabi GCC
+hytiny-stm32f103t.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+hytiny-stm32f103t.menu.tchain.eabi.build.flags.ldspecs=
+
 ########################### STM32VLD to FLASH ###########################
 
 STM32VLD.name=STM32VLD to FLASH
@@ -1125,5 +1198,11 @@ STM32VLD.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 STM32VLD.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 STM32VLD.menu.rtlib.full=Newlib Standard
 STM32VLD.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+STM32VLD.menu.tchain.xpack=xPack GCC 9 (default)
+STM32VLD.menu.tchain.eabi=Arm none eabi GCC
+STM32VLD.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+STM32VLD.menu.tchain.eabi.build.flags.ldspecs=
 
 ################################################################################

--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -5,6 +5,7 @@ menu.bootloader_version=Bootloader version
 menu.upload_method=Upload method
 menu.cpu_speed=CPU Speed(MHz)
 menu.opt=Optimize
+menu.rtlib=C Runtime Library
 
 ##############################################################
 mapleMini.name=Maple Mini
@@ -51,29 +52,31 @@ mapleMini.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 mapleMini.menu.opt.osstd=Smallest (default)
 #mapleMini.menu.opt.oslto=Smallest Code with LTO
 #mapleMini.menu.opt.oslto.build.flags.optimize=-Os -flto
-#mapleMini.menu.opt.oslto.build.flags.ldspecs=-flto
 mapleMini.menu.opt.o1std=Fast (-O1)
 mapleMini.menu.opt.o1std.build.flags.optimize=-O1
-mapleMini.menu.opt.o1std.build.flags.ldspecs=
 #mapleMini.menu.opt.o1lto=Fast (-O1) with LTO
 #mapleMini.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#mapleMini.menu.opt.o1lto.build.flags.ldspecs=-flto
 mapleMini.menu.opt.o2std=Faster (-O2)
 mapleMini.menu.opt.o2std.build.flags.optimize=-O2
-mapleMini.menu.opt.o2std.build.flags.ldspecs=
 #mapleMini.menu.opt.o2lto=Faster (-O2) with LTO
 #mapleMini.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#mapleMini.menu.opt.o2lto.build.flags.ldspecs=-flto
 mapleMini.menu.opt.o3std=Fastest (-O3)
 mapleMini.menu.opt.o3std.build.flags.optimize=-O3
-mapleMini.menu.opt.o3std.build.flags.ldspecs=
 #mapleMini.menu.opt.o3lto=Fastest (-O3) with LTO
 #mapleMini.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#mapleMini.menu.opt.o3lto.build.flags.ldspecs=-flto
 mapleMini.menu.opt.ogstd=Debug (-g)
 mapleMini.menu.opt.ogstd.build.flags.optimize=-Og
-mapleMini.menu.opt.ogstd.build.flags.ldspecs=
 
+# C Runtime library
+mapleMini.menu.rtlib.nano=Newlib Nano (default)
+mapleMini.menu.rtlib.nanofp=Newlib Nano + Float Printf
+mapleMini.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+mapleMini.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+mapleMini.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+mapleMini.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+mapleMini.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+mapleMini.menu.rtlib.full=Newlib Standard
+mapleMini.menu.rtlib.full.build.flags.ldspecs=
 
 ##############################################################
 maple.name=Maple (Rev 3)
@@ -111,28 +114,31 @@ maple.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 maple.menu.opt.osstd=Smallest (default)
 #maple.menu.opt.oslto=Smallest Code with LTO
 #maple.menu.opt.oslto.build.flags.optimize=-Os -flto
-#maple.menu.opt.oslto.build.flags.ldspecs=-flto
 maple.menu.opt.o1std=Fast (-O1)
 maple.menu.opt.o1std.build.flags.optimize=-O1
-maple.menu.opt.o1std.build.flags.ldspecs=
 #maple.menu.opt.o1lto=Fast (-O1) with LTO
 #maple.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#maple.menu.opt.o1lto.build.flags.ldspecs=-flto
 maple.menu.opt.o2std=Faster (-O2)
 maple.menu.opt.o2std.build.flags.optimize=-O2
-maple.menu.opt.o2std.build.flags.ldspecs=
 #maple.menu.opt.o2lto=Faster (-O2) with LTO
 #maple.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#maple.menu.opt.o2lto.build.flags.ldspecs=-flto
 maple.menu.opt.o3std=Fastest (-O3)
 maple.menu.opt.o3std.build.flags.optimize=-O3
-maple.menu.opt.o3std.build.flags.ldspecs=
 #maple.menu.opt.o3lto=Fastest (-O3) with LTO
 #maple.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#maple.menu.opt.o3lto.build.flags.ldspecs=-flto
 maple.menu.opt.ogstd=Debug (-g)
 maple.menu.opt.ogstd.build.flags.optimize=-Og
-maple.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+maple.menu.rtlib.nano=Newlib Nano (default)
+maple.menu.rtlib.nanofp=Newlib Nano + Float Printf
+maple.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+maple.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+maple.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+maple.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+maple.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+maple.menu.rtlib.full=Newlib Standard
+maple.menu.rtlib.full.build.flags.ldspecs=
 
 ##############################################################
 mapleRET6.name=Maple (RET6)
@@ -172,28 +178,31 @@ mapleRET6.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 mapleRET6.menu.opt.osstd=Smallest (default)
 #mapleRET6.menu.opt.oslto=Smallest Code with LTO
 #mapleRET6.menu.opt.oslto.build.flags.optimize=-Os -flto
-#mapleRET6.menu.opt.oslto.build.flags.ldspecs=-flto
 mapleRET6.menu.opt.o1std=Fast (-O1)
 mapleRET6.menu.opt.o1std.build.flags.optimize=-O1
-mapleRET6.menu.opt.o1std.build.flags.ldspecs=
 #mapleRET6.menu.opt.o1lto=Fast (-O1) with LTO
 #mapleRET6.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#mapleRET6.menu.opt.o1lto.build.flags.ldspecs=-flto
 mapleRET6.menu.opt.o2std=Faster (-O2)
 mapleRET6.menu.opt.o2std.build.flags.optimize=-O2
-mapleRET6.menu.opt.o2std.build.flags.ldspecs=
 #mapleRET6.menu.opt.o2lto=Faster (-O2) with LTO
 #mapleRET6.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#mapleRET6.menu.opt.o2lto.build.flags.ldspecs=-flto
 mapleRET6.menu.opt.o3std=Fastest (-O3)
 mapleRET6.menu.opt.o3std.build.flags.optimize=-O3
-mapleRET6.menu.opt.o3std.build.flags.ldspecs=
 #mapleRET6.menu.opt.o3lto=Fastest (-O3) with LTO
 #mapleRET6.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#mapleRET6.menu.opt.o3lto.build.flags.ldspecs=-flto
 mapleRET6.menu.opt.ogstd=Debug (-g)
 mapleRET6.menu.opt.ogstd.build.flags.optimize=-Og
-mapleRET6.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+mapleRET6.menu.rtlib.nano=Newlib Nano (default)
+mapleRET6.menu.rtlib.nanofp=Newlib Nano + Float Printf
+mapleRET6.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+mapleRET6.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+mapleRET6.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+mapleRET6.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+mapleRET6.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+mapleRET6.menu.rtlib.full=Newlib Standard
+mapleRET6.menu.rtlib.full.build.flags.ldspecs=
 
 ##############################################################
 
@@ -240,28 +249,31 @@ microduino32_flash.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 microduino32_flash.menu.opt.osstd=Smallest (default)
 #microduino32_flash.menu.opt.oslto=Smallest Code with LTO
 #microduino32_flash.menu.opt.oslto.build.flags.optimize=-Os -flto
-#microduino32_flash.menu.opt.oslto.build.flags.ldspecs=-flto
 microduino32_flash.menu.opt.o1std=Fast (-O1)
 microduino32_flash.menu.opt.o1std.build.flags.optimize=-O1
-microduino32_flash.menu.opt.o1std.build.flags.ldspecs=
 #microduino32_flash.menu.opt.o1lto=Fast (-O1) with LTO
 #microduino32_flash.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#microduino32_flash.menu.opt.o1lto.build.flags.ldspecs=-flto
 microduino32_flash.menu.opt.o2std=Faster (-O2)
 microduino32_flash.menu.opt.o2std.build.flags.optimize=-O2
-microduino32_flash.menu.opt.o2std.build.flags.ldspecs=
 #microduino32_flash.menu.opt.o2lto=Faster (-O2) with LTO
 #microduino32_flash.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#microduino32_flash.menu.opt.o2lto.build.flags.ldspecs=-flto
 microduino32_flash.menu.opt.o3std=Fastest (-O3)
 microduino32_flash.menu.opt.o3std.build.flags.optimize=-O3
-microduino32_flash.menu.opt.o3std.build.flags.ldspecs=
 #microduino32_flash.menu.opt.o3lto=Fastest (-O3) with LTO
 #microduino32_flash.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#microduino32_flash.menu.opt.o3lto.build.flags.ldspecs=-flto
 microduino32_flash.menu.opt.ogstd=Debug (-g)
 microduino32_flash.menu.opt.ogstd.build.flags.optimize=-Og
-microduino32_flash.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+microduino32_flash.menu.rtlib.nano=Newlib Nano (default)
+microduino32_flash.menu.rtlib.nanofp=Newlib Nano + Float Printf
+microduino32_flash.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+microduino32_flash.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+microduino32_flash.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+microduino32_flash.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+microduino32_flash.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+microduino32_flash.menu.rtlib.full=Newlib Standard
+microduino32_flash.menu.rtlib.full.build.flags.ldspecs=
 
 ##############################################################
 nucleo_f103rb.name=STM Nucleo F103RB (STLink)
@@ -304,28 +316,31 @@ nucleo_f103rb.menu.device_variant.NucleoF103_HSE.build.extra_flags=-DNUCLEO_HSE_
 nucleo_f103rb.menu.opt.osstd=Smallest (default)
 #nucleo_f103rb.menu.opt.oslto=Smallest Code with LTO
 #nucleo_f103rb.menu.opt.oslto.build.flags.optimize=-Os -flto
-#nucleo_f103rb.menu.opt.oslto.build.flags.ldspecs=-flto
 nucleo_f103rb.menu.opt.o1std=Fast (-O1)
 nucleo_f103rb.menu.opt.o1std.build.flags.optimize=-O1
-nucleo_f103rb.menu.opt.o1std.build.flags.ldspecs=
 #nucleo_f103rb.menu.opt.o1lto=Fast (-O1) with LTO
 #nucleo_f103rb.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#nucleo_f103rb.menu.opt.o1lto.build.flags.ldspecs=-flto
 nucleo_f103rb.menu.opt.o2std=Faster (-O2)
 nucleo_f103rb.menu.opt.o2std.build.flags.optimize=-O2
-nucleo_f103rb.menu.opt.o2std.build.flags.ldspecs=
 #nucleo_f103rb.menu.opt.o2lto=Faster (-O2) with LTO
 #nucleo_f103rb.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#nucleo_f103rb.menu.opt.o2lto.build.flags.ldspecs=-flto
 nucleo_f103rb.menu.opt.o3std=Fastest (-O3)
 nucleo_f103rb.menu.opt.o3std.build.flags.optimize=-O3
-nucleo_f103rb.menu.opt.o3std.build.flags.ldspecs=
 #nucleo_f103rb.menu.opt.o3lto=Fastest (-O3) with LTO
 #nucleo_f103rb.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#nucleo_f103rb.menu.opt.o3lto.build.flags.ldspecs=-flto
 nucleo_f103rb.menu.opt.ogstd=Debug (-g)
 nucleo_f103rb.menu.opt.ogstd.build.flags.optimize=-Og
-nucleo_f103rb.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+nucleo_f103rb.menu.rtlib.nano=Newlib Nano (default)
+nucleo_f103rb.menu.rtlib.nanofp=Newlib Nano + Float Printf
+nucleo_f103rb.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+nucleo_f103rb.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+nucleo_f103rb.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+nucleo_f103rb.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+nucleo_f103rb.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+nucleo_f103rb.menu.rtlib.full=Newlib Standard
+nucleo_f103rb.menu.rtlib.full.build.flags.ldspecs=
 
 ###################### Generic STM32F103C ########################################
 
@@ -409,28 +424,31 @@ genericSTM32F103C.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 genericSTM32F103C.menu.opt.osstd=Smallest (default)
 #genericSTM32F103C.menu.opt.oslto=Smallest Code with LTO
 #genericSTM32F103C.menu.opt.oslto.build.flags.optimize=-Os -flto
-#genericSTM32F103C.menu.opt.oslto.build.flags.ldspecs=-flto
 genericSTM32F103C.menu.opt.o1std=Fast (-O1)
 genericSTM32F103C.menu.opt.o1std.build.flags.optimize=-O1
-genericSTM32F103C.menu.opt.o1std.build.flags.ldspecs=
 #genericSTM32F103C.menu.opt.o1lto=Fast (-O1) with LTO
 #genericSTM32F103C.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#genericSTM32F103C.menu.opt.o1lto.build.flags.ldspecs=-flto
 genericSTM32F103C.menu.opt.o2std=Faster (-O2)
 genericSTM32F103C.menu.opt.o2std.build.flags.optimize=-O2
-genericSTM32F103C.menu.opt.o2std.build.flags.ldspecs=
 #genericSTM32F103C.menu.opt.o2lto=Faster (-O2) with LTO
 #genericSTM32F103C.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#genericSTM32F103C.menu.opt.o2lto.build.flags.ldspecs=-flto
 genericSTM32F103C.menu.opt.o3std=Fastest (-O3)
 genericSTM32F103C.menu.opt.o3std.build.flags.optimize=-O3
-genericSTM32F103C.menu.opt.o3std.build.flags.ldspecs=
 #genericSTM32F103C.menu.opt.o3lto=Fastest (-O3) with LTO
 #genericSTM32F103C.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#genericSTM32F103C.menu.opt.o3lto.build.flags.ldspecs=-flto
 genericSTM32F103C.menu.opt.ogstd=Debug (-g)
 genericSTM32F103C.menu.opt.ogstd.build.flags.optimize=-Og
-genericSTM32F103C.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+genericSTM32F103C.menu.rtlib.nano=Newlib Nano (default)
+genericSTM32F103C.menu.rtlib.nanofp=Newlib Nano + Float Printf
+genericSTM32F103C.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+genericSTM32F103C.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+genericSTM32F103C.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+genericSTM32F103C.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+genericSTM32F103C.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+genericSTM32F103C.menu.rtlib.full=Newlib Standard
+genericSTM32F103C.menu.rtlib.full.build.flags.ldspecs=
 
 ###################### Generic STM32F103C6 ########################################
 
@@ -505,28 +523,31 @@ genericSTM32F103C6.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 genericSTM32F103C6.menu.opt.osstd=Smallest (default)
 #genericSTM32F103C6.menu.opt.oslto=Smallest Code with LTO
 #genericSTM32F103C6.menu.opt.oslto.build.flags.optimize=-Os -flto
-#genericSTM32F103C6.menu.opt.oslto.build.flags.ldspecs=-flto
 genericSTM32F103C6.menu.opt.o1std=Fast (-O1)
 genericSTM32F103C6.menu.opt.o1std.build.flags.optimize=-O1
-genericSTM32F103C6.menu.opt.o1std.build.flags.ldspecs=
 #genericSTM32F103C6.menu.opt.o1lto=Fast (-O1) with LTO
 #genericSTM32F103C6.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#genericSTM32F103C6.menu.opt.o1lto.build.flags.ldspecs=-flto
 genericSTM32F103C6.menu.opt.o2std=Faster (-O2)
 genericSTM32F103C6.menu.opt.o2std.build.flags.optimize=-O2
-genericSTM32F103C6.menu.opt.o2std.build.flags.ldspecs=
 #genericSTM32F103C6.menu.opt.o2lto=Faster (-O2) with LTO
 #genericSTM32F103C6.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#genericSTM32F103C6.menu.opt.o2lto.build.flags.ldspecs=-flto
 genericSTM32F103C6.menu.opt.o3std=Fastest (-O3)
 genericSTM32F103C6.menu.opt.o3std.build.flags.optimize=-O3
-genericSTM32F103C6.menu.opt.o3std.build.flags.ldspecs=
 #genericSTM32F103C6.menu.opt.o3lto=Fastest (-O3) with LTO
 #genericSTM32F103C6.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#genericSTM32F103C6.menu.opt.o3lto.build.flags.ldspecs=-flto
 genericSTM32F103C6.menu.opt.ogstd=Debug (-g)
 genericSTM32F103C6.menu.opt.ogstd.build.flags.optimize=-Og
-genericSTM32F103C6.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+genericSTM32F103C6.menu.rtlib.nano=Newlib Nano (default)
+genericSTM32F103C6.menu.rtlib.nanofp=Newlib Nano + Float Printf
+genericSTM32F103C6.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+genericSTM32F103C6.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+genericSTM32F103C6.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+genericSTM32F103C6.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+genericSTM32F103C6.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+genericSTM32F103C6.menu.rtlib.full=Newlib Standard
+genericSTM32F103C6.menu.rtlib.full.build.flags.ldspecs=
 
 ########################### Generic STM32F103R ###########################
 
@@ -614,28 +635,31 @@ genericSTM32F103R.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 genericSTM32F103R.menu.opt.osstd=Smallest (default)
 #genericSTM32F103R.menu.opt.oslto=Smallest Code with LTO
 #genericSTM32F103R.menu.opt.oslto.build.flags.optimize=-Os -flto
-#genericSTM32F103R.menu.opt.oslto.build.flags.ldspecs=-flto
 genericSTM32F103R.menu.opt.o1std=Fast (-O1)
 genericSTM32F103R.menu.opt.o1std.build.flags.optimize=-O1
-genericSTM32F103R.menu.opt.o1std.build.flags.ldspecs=
 #genericSTM32F103R.menu.opt.o1lto=Fast (-O1) with LTO
 #genericSTM32F103R.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#genericSTM32F103R.menu.opt.o1lto.build.flags.ldspecs=-flto
 genericSTM32F103R.menu.opt.o2std=Faster (-O2)
 genericSTM32F103R.menu.opt.o2std.build.flags.optimize=-O2
-genericSTM32F103R.menu.opt.o2std.build.flags.ldspecs=
 #genericSTM32F103R.menu.opt.o2lto=Faster (-O2) with LTO
 #genericSTM32F103R.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#genericSTM32F103R.menu.opt.o2lto.build.flags.ldspecs=-flto
 genericSTM32F103R.menu.opt.o3std=Fastest (-O3)
 genericSTM32F103R.menu.opt.o3std.build.flags.optimize=-O3
-genericSTM32F103R.menu.opt.o3std.build.flags.ldspecs=
 #genericSTM32F103R.menu.opt.o3lto=Fastest (-O3) with LTO
 #genericSTM32F103R.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#genericSTM32F103R.menu.opt.o3lto.build.flags.ldspecs=-flto
 genericSTM32F103R.menu.opt.ogstd=Debug (-g)
 genericSTM32F103R.menu.opt.ogstd.build.flags.optimize=-Og
-genericSTM32F103R.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+genericSTM32F103R.menu.rtlib.nano=Newlib Nano (default)
+genericSTM32F103R.menu.rtlib.nanofp=Newlib Nano + Float Printf
+genericSTM32F103R.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+genericSTM32F103R.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+genericSTM32F103R.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+genericSTM32F103R.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+genericSTM32F103R.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+genericSTM32F103R.menu.rtlib.full=Newlib Standard
+genericSTM32F103R.menu.rtlib.full.build.flags.ldspecs=
 
 ###################### Generic STM32F103T ########################################
 
@@ -706,28 +730,31 @@ genericSTM32F103T.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 genericSTM32F103T.menu.opt.osstd=Smallest (default)
 #genericSTM32F103T.menu.opt.oslto=Smallest Code with LTO
 #genericSTM32F103T.menu.opt.oslto.build.flags.optimize=-Os -flto
-#genericSTM32F103T.menu.opt.oslto.build.flags.ldspecs=-flto
 genericSTM32F103T.menu.opt.o1std=Fast (-O1)
 genericSTM32F103T.menu.opt.o1std.build.flags.optimize=-O1
-genericSTM32F103T.menu.opt.o1std.build.flags.ldspecs=
 #genericSTM32F103T.menu.opt.o1lto=Fast (-O1) with LTO
 #genericSTM32F103T.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#genericSTM32F103T.menu.opt.o1lto.build.flags.ldspecs=-flto
 genericSTM32F103T.menu.opt.o2std=Faster (-O2)
 genericSTM32F103T.menu.opt.o2std.build.flags.optimize=-O2
-genericSTM32F103T.menu.opt.o2std.build.flags.ldspecs=
 #genericSTM32F103T.menu.opt.o2lto=Faster (-O2) with LTO
 #genericSTM32F103T.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#genericSTM32F103T.menu.opt.o2lto.build.flags.ldspecs=-flto
 genericSTM32F103T.menu.opt.o3std=Fastest (-O3)
 genericSTM32F103T.menu.opt.o3std.build.flags.optimize=-O3
-genericSTM32F103T.menu.opt.o3std.build.flags.ldspecs=
 #genericSTM32F103T.menu.opt.o3lto=Fastest (-O3) with LTO
 #genericSTM32F103T.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#genericSTM32F103T.menu.opt.o3lto.build.flags.ldspecs=-flto
 genericSTM32F103T.menu.opt.ogstd=Debug (-g)
 genericSTM32F103T.menu.opt.ogstd.build.flags.optimize=-Og
-genericSTM32F103T.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+genericSTM32F103T.menu.rtlib.nano=Newlib Nano (default)
+genericSTM32F103T.menu.rtlib.nanofp=Newlib Nano + Float Printf
+genericSTM32F103T.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+genericSTM32F103T.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+genericSTM32F103T.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+genericSTM32F103T.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+genericSTM32F103T.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+genericSTM32F103T.menu.rtlib.full=Newlib Standard
+genericSTM32F103T.menu.rtlib.full.build.flags.ldspecs=
 
 ########################### Generic STM32F103V ###########################
 
@@ -815,28 +842,31 @@ genericSTM32F103V.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 genericSTM32F103V.menu.opt.osstd=Smallest (default)
 #genericSTM32F103V.menu.opt.oslto=Smallest Code with LTO
 #genericSTM32F103V.menu.opt.oslto.build.flags.optimize=-Os -flto
-#genericSTM32F103V.menu.opt.oslto.build.flags.ldspecs=-flto
 genericSTM32F103V.menu.opt.o1std=Fast (-O1)
 genericSTM32F103V.menu.opt.o1std.build.flags.optimize=-O1
-genericSTM32F103V.menu.opt.o1std.build.flags.ldspecs=
 #genericSTM32F103V.menu.opt.o1lto=Fast (-O1) with LTO
 #genericSTM32F103V.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#genericSTM32F103V.menu.opt.o1lto.build.flags.ldspecs=-flto
 genericSTM32F103V.menu.opt.o2std=Faster (-O2)
 genericSTM32F103V.menu.opt.o2std.build.flags.optimize=-O2
-genericSTM32F103V.menu.opt.o2std.build.flags.ldspecs=
 #genericSTM32F103V.menu.opt.o2lto=Faster (-O2) with LTO
 #genericSTM32F103V.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#genericSTM32F103V.menu.opt.o2lto.build.flags.ldspecs=-flto
 genericSTM32F103V.menu.opt.o3std=Fastest (-O3)
 genericSTM32F103V.menu.opt.o3std.build.flags.optimize=-O3
-genericSTM32F103V.menu.opt.o3std.build.flags.ldspecs=
 #genericSTM32F103V.menu.opt.o3lto=Fastest (-O3) with LTO
 #genericSTM32F103V.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#genericSTM32F103V.menu.opt.o3lto.build.flags.ldspecs=-flto
 genericSTM32F103V.menu.opt.ogstd=Debug (-g)
 genericSTM32F103V.menu.opt.ogstd.build.flags.optimize=-Og
-genericSTM32F103V.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+genericSTM32F103V.menu.rtlib.nano=Newlib Nano (default)
+genericSTM32F103V.menu.rtlib.nanofp=Newlib Nano + Float Printf
+genericSTM32F103V.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+genericSTM32F103V.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+genericSTM32F103V.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+genericSTM32F103V.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+genericSTM32F103V.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+genericSTM32F103V.menu.rtlib.full=Newlib Standard
+genericSTM32F103V.menu.rtlib.full.build.flags.ldspecs=
 
 ########################### Generic STM32F103Z ###########################
 
@@ -911,28 +941,31 @@ genericSTM32F103Z.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 genericSTM32F103Z.menu.opt.osstd=Smallest (default)
 #genericSTM32F103Z.menu.opt.oslto=Smallest Code with LTO
 #genericSTM32F103Z.menu.opt.oslto.build.flags.optimize=-Os -flto
-#genericSTM32F103Z.menu.opt.oslto.build.flags.ldspecs=-flto
 genericSTM32F103Z.menu.opt.o1std=Fast (-O1)
 genericSTM32F103Z.menu.opt.o1std.build.flags.optimize=-O1
-genericSTM32F103Z.menu.opt.o1std.build.flags.ldspecs=
 #genericSTM32F103Z.menu.opt.o1lto=Fast (-O1) with LTO
 #genericSTM32F103Z.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#genericSTM32F103Z.menu.opt.o1lto.build.flags.ldspecs=-flto
 genericSTM32F103Z.menu.opt.o2std=Faster (-O2)
 genericSTM32F103Z.menu.opt.o2std.build.flags.optimize=-O2
-genericSTM32F103Z.menu.opt.o2std.build.flags.ldspecs=
 #genericSTM32F103Z.menu.opt.o2lto=Faster (-O2) with LTO
 #genericSTM32F103Z.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#genericSTM32F103Z.menu.opt.o2lto.build.flags.ldspecs=-flto
 genericSTM32F103Z.menu.opt.o3std=Fastest (-O3)
 genericSTM32F103Z.menu.opt.o3std.build.flags.optimize=-O3
-genericSTM32F103Z.menu.opt.o3std.build.flags.ldspecs=
 #genericSTM32F103Z.menu.opt.o3lto=Fastest (-O3) with LTO
 #genericSTM32F103Z.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#genericSTM32F103Z.menu.opt.o3lto.build.flags.ldspecs=-flto
 genericSTM32F103Z.menu.opt.ogstd=Debug (-g)
 genericSTM32F103Z.menu.opt.ogstd.build.flags.optimize=-Og
-genericSTM32F103Z.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+genericSTM32F103Z.menu.rtlib.nano=Newlib Nano (default)
+genericSTM32F103Z.menu.rtlib.nanofp=Newlib Nano + Float Printf
+genericSTM32F103Z.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+genericSTM32F103Z.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+genericSTM32F103Z.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+genericSTM32F103Z.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+genericSTM32F103Z.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+genericSTM32F103Z.menu.rtlib.full=Newlib Standard
+genericSTM32F103Z.menu.rtlib.full.build.flags.ldspecs=
 
 ###################### HYTiny STM32F103T ########################################
 
@@ -999,28 +1032,31 @@ hytiny-stm32f103t.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 hytiny-stm32f103t.menu.opt.osstd=Smallest (default)
 #hytiny-stm32f103t.menu.opt.oslto=Smallest Code with LTO
 #hytiny-stm32f103t.menu.opt.oslto.build.flags.optimize=-Os -flto
-#hytiny-stm32f103t.menu.opt.oslto.build.flags.ldspecs=-flto
 hytiny-stm32f103t.menu.opt.o1std=Fast (-O1)
 hytiny-stm32f103t.menu.opt.o1std.build.flags.optimize=-O1
-hytiny-stm32f103t.menu.opt.o1std.build.flags.ldspecs=
 #hytiny-stm32f103t.menu.opt.o1lto=Fast (-O1) with LTO
 #hytiny-stm32f103t.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#hytiny-stm32f103t.menu.opt.o1lto.build.flags.ldspecs=-flto
 hytiny-stm32f103t.menu.opt.o2std=Faster (-O2)
 hytiny-stm32f103t.menu.opt.o2std.build.flags.optimize=-O2
-hytiny-stm32f103t.menu.opt.o2std.build.flags.ldspecs=
 #hytiny-stm32f103t.menu.opt.o2lto=Faster (-O2) with LTO
 #hytiny-stm32f103t.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#hytiny-stm32f103t.menu.opt.o2lto.build.flags.ldspecs=-flto
 hytiny-stm32f103t.menu.opt.o3std=Fastest (-O3)
 hytiny-stm32f103t.menu.opt.o3std.build.flags.optimize=-O3
-hytiny-stm32f103t.menu.opt.o3std.build.flags.ldspecs=
 #hytiny-stm32f103t.menu.opt.o3lto=Fastest (-O3) with LTO
 #hytiny-stm32f103t.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#hytiny-stm32f103t.menu.opt.o3lto.build.flags.ldspecs=-flto
 hytiny-stm32f103t.menu.opt.ogstd=Debug (-g)
 hytiny-stm32f103t.menu.opt.ogstd.build.flags.optimize=-Og
-hytiny-stm32f103t.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+hytiny-stm32f103t.menu.rtlib.nano=Newlib Nano (default)
+hytiny-stm32f103t.menu.rtlib.nanofp=Newlib Nano + Float Printf
+hytiny-stm32f103t.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+hytiny-stm32f103t.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+hytiny-stm32f103t.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+hytiny-stm32f103t.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+hytiny-stm32f103t.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+hytiny-stm32f103t.menu.rtlib.full=Newlib Standard
+hytiny-stm32f103t.menu.rtlib.full.build.flags.ldspecs=
 
 ########################### STM32VLD to FLASH ###########################
 
@@ -1064,27 +1100,30 @@ STM32VLD.menu.cpu_speed.speed_128mhz.build.f_cpu=128000000L
 STM32VLD.menu.opt.osstd=Smallest (default)
 #STM32VLD.menu.opt.oslto=Smallest Code with LTO
 #STM32VLD.menu.opt.oslto.build.flags.optimize=-Os -flto
-#STM32VLD.menu.opt.oslto.build.flags.ldspecs=-flto
 STM32VLD.menu.opt.o1std=Fast (-O1)
 STM32VLD.menu.opt.o1std.build.flags.optimize=-O1
-STM32VLD.menu.opt.o1std.build.flags.ldspecs=
 #STM32VLD.menu.opt.o1lto=Fast (-O1) with LTO
 #STM32VLD.menu.opt.o1lto.build.flags.optimize=-O1 -flto
-#STM32VLD.menu.opt.o1lto.build.flags.ldspecs=-flto
 STM32VLD.menu.opt.o2std=Faster (-O2)
 STM32VLD.menu.opt.o2std.build.flags.optimize=-O2
-STM32VLD.menu.opt.o2std.build.flags.ldspecs=
 #STM32VLD.menu.opt.o2lto=Faster (-O2) with LTO
 #STM32VLD.menu.opt.o2lto.build.flags.optimize=-O2 -flto
-#STM32VLD.menu.opt.o2lto.build.flags.ldspecs=-flto
 STM32VLD.menu.opt.o3std=Fastest (-O3)
 STM32VLD.menu.opt.o3std.build.flags.optimize=-O3
-STM32VLD.menu.opt.o3std.build.flags.ldspecs=
 #STM32VLD.menu.opt.o3lto=Fastest (-O3) with LTO
 #STM32VLD.menu.opt.o3lto.build.flags.optimize=-O3 -flto
-#STM32VLD.menu.opt.o3lto.build.flags.ldspecs=-flto
 STM32VLD.menu.opt.ogstd=Debug (-g)
 STM32VLD.menu.opt.ogstd.build.flags.optimize=-Og
-STM32VLD.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+STM32VLD.menu.rtlib.nano=Newlib Nano (default)
+STM32VLD.menu.rtlib.nanofp=Newlib Nano + Float Printf
+STM32VLD.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+STM32VLD.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+STM32VLD.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+STM32VLD.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+STM32VLD.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+STM32VLD.menu.rtlib.full=Newlib Standard
+STM32VLD.menu.rtlib.full.build.flags.ldspecs=
 
 ################################################################################

--- a/STM32F1/platform.txt
+++ b/STM32F1/platform.txt
@@ -14,7 +14,7 @@ compiler.warning_flags.all=-Wall -Wextra -DDEBUG_LEVEL=DEBUG_ALL
 
 # compiler variables
 # ----------------------
-compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-9.2.1-1.1.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-c -g {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant} -D{build.vect} -DERROR_LED_PORT={build.error_led_port} -DERROR_LED_PIN={build.error_led_pin} 
 compiler.c.elf.cmd=arm-none-eabi-g++
@@ -45,7 +45,7 @@ build.cpu_flags=
 build.hs_flag=
 build.upload_flags=
 build.flags.optimize=-Os
-build.flags.ldspecs=
+build.flags.ldspecs=--specs=nano.specs
 build.extra_flags= {build.upload_flags} {build.cpu_flags} {build.hs_flag} {build.common_flags}
 
 

--- a/STM32F4/boards.txt
+++ b/STM32F4/boards.txt
@@ -3,6 +3,7 @@
 menu.usb_cfg=USB configuration
 menu.opt=Optimize
 menu.upload_method=Upload method
+menu.rtlib=C Runtime Library
 
 ##############################################################
 discovery_f407.name=STM32 Discovery F407
@@ -62,6 +63,18 @@ discovery_f407.menu.opt.o3lto.build.flags.ldspecs=-flto
 discovery_f407.menu.opt.ogstd=Debug (-g)
 discovery_f407.menu.opt.ogstd.build.flags.optimize=-Og
 discovery_f407.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+discovery_f407.menu.rtlib.nano=Newlib Nano (default)
+discovery_f407.menu.rtlib.nanofp=Newlib Nano + Float Printf
+discovery_f407.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+discovery_f407.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+discovery_f407.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+discovery_f407.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+discovery_f407.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+discovery_f407.menu.rtlib.full=Newlib Standard
+discovery_f407.menu.rtlib.full.build.flags.ldspecs=
+
 ##############################################################
 blackpill_f401.name=Blackpill STM32F401CCU6
 
@@ -115,6 +128,18 @@ blackpill_f401.menu.opt.o3lto.build.flags.ldspecs=-flto
 blackpill_f401.menu.opt.ogstd=Debug (-g)
 blackpill_f401.menu.opt.ogstd.build.flags.optimize=-Og
 blackpill_f401.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+blackpill_f401.menu.rtlib.nano=Newlib Nano (default)
+blackpill_f401.menu.rtlib.nanofp=Newlib Nano + Float Printf
+blackpill_f401.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+blackpill_f401.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+blackpill_f401.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+blackpill_f401.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+blackpill_f401.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+blackpill_f401.menu.rtlib.full=Newlib Standard
+blackpill_f401.menu.rtlib.full.build.flags.ldspecs=
+
 ##############################################################
 disco_f411.name=STM32 Discovery F411E
 
@@ -168,6 +193,18 @@ disco_f411.menu.opt.o3lto.build.flags.ldspecs=-flto
 disco_f411.menu.opt.ogstd=Debug (-g)
 disco_f411.menu.opt.ogstd.build.flags.optimize=-Og
 disco_f411.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+disco_f411.menu.rtlib.nano=Newlib Nano (default)
+disco_f411.menu.rtlib.nanofp=Newlib Nano + Float Printf
+disco_f411.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+disco_f411.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+disco_f411.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+disco_f411.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+disco_f411.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+disco_f411.menu.rtlib.full=Newlib Standard
+disco_f411.menu.rtlib.full.build.flags.ldspecs=
+
 ##############################################################
 generic_f407v.name=Generic STM32F407V series
 
@@ -234,6 +271,18 @@ generic_f407v.menu.opt.o3lto.build.flags.ldspecs=-flto
 generic_f407v.menu.opt.ogstd=Debug (-g)
 generic_f407v.menu.opt.ogstd.build.flags.optimize=-Og
 generic_f407v.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+generic_f407v.menu.rtlib.nano=Newlib Nano (default)
+generic_f407v.menu.rtlib.nanofp=Newlib Nano + Float Printf
+generic_f407v.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+generic_f407v.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+generic_f407v.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+generic_f407v.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+generic_f407v.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+generic_f407v.menu.rtlib.full=Newlib Standard
+generic_f407v.menu.rtlib.full.build.flags.ldspecs=
+
 ##############################################################
 generic_f407v_mini.name=Generic STM32F407V mini series
 
@@ -302,6 +351,18 @@ generic_f407v_mini.menu.opt.o3lto.build.flags.ldspecs=-flto
 generic_f407v_mini.menu.opt.ogstd=Debug (-g)
 generic_f407v_mini.menu.opt.ogstd.build.flags.optimize=-Og
 generic_f407v_mini.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+generic_f407v_mini.menu.rtlib.nano=Newlib Nano (default)
+generic_f407v_mini.menu.rtlib.nanofp=Newlib Nano + Float Printf
+generic_f407v_mini.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+generic_f407v_mini.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+generic_f407v_mini.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+generic_f407v_mini.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+generic_f407v_mini.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+generic_f407v_mini.menu.rtlib.full=Newlib Standard
+generic_f407v_mini.menu.rtlib.full.build.flags.ldspecs=
+
 ##############################################################
 arch_max.name=Seeed Arch Max 1.1
 
@@ -364,5 +425,17 @@ arch_max.menu.opt.o3lto.build.flags.ldspecs=-flto
 arch_max.menu.opt.ogstd=Debug (-g)
 arch_max.menu.opt.ogstd.build.flags.optimize=-Og
 arch_max.menu.opt.ogstd.build.flags.ldspecs=
+
+# C Runtime library
+arch_max.menu.rtlib.nano=Newlib Nano (default)
+arch_max.menu.rtlib.nanofp=Newlib Nano + Float Printf
+arch_max.menu.rtlib.nanofp.build.flags.ldspecs=--specs=nano.specs -u _printf_float
+arch_max.menu.rtlib.nanofs=Newlib Nano + Float Scanf
+arch_max.menu.rtlib.nanofs.build.flags.ldspecs=--specs=nano.specs -u _scanf_float
+arch_max.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
+arch_max.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
+arch_max.menu.rtlib.full=Newlib Standard
+arch_max.menu.rtlib.full.build.flags.ldspecs=
+
 ##############################################################
 

--- a/STM32F4/boards.txt
+++ b/STM32F4/boards.txt
@@ -4,6 +4,7 @@ menu.usb_cfg=USB configuration
 menu.opt=Optimize
 menu.upload_method=Upload method
 menu.rtlib=C Runtime Library
+menu.tchain=Toolchain
 
 ##############################################################
 discovery_f407.name=STM32 Discovery F407
@@ -75,6 +76,12 @@ discovery_f407.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _pri
 discovery_f407.menu.rtlib.full=Newlib Standard
 discovery_f407.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+discovery_f407.menu.tchain.xpack=xPack GCC 9 (default)
+discovery_f407.menu.tchain.eabi=Arm none eabi GCC
+discovery_f407.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+discovery_f407.menu.tchain.eabi.build.flags.ldspecs=
+
 ##############################################################
 blackpill_f401.name=Blackpill STM32F401CCU6
 
@@ -140,6 +147,12 @@ blackpill_f401.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _pri
 blackpill_f401.menu.rtlib.full=Newlib Standard
 blackpill_f401.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+blackpill_f401.menu.tchain.xpack=xPack GCC 9 (default)
+blackpill_f401.menu.tchain.eabi=Arm none eabi GCC
+blackpill_f401.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+blackpill_f401.menu.tchain.eabi.build.flags.ldspecs=
+
 ##############################################################
 disco_f411.name=STM32 Discovery F411E
 
@@ -204,6 +217,12 @@ disco_f411.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 disco_f411.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 disco_f411.menu.rtlib.full=Newlib Standard
 disco_f411.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+disco_f411.menu.tchain.xpack=xPack GCC 9 (default)
+disco_f411.menu.tchain.eabi=Arm none eabi GCC
+disco_f411.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+disco_f411.menu.tchain.eabi.build.flags.ldspecs=
 
 ##############################################################
 generic_f407v.name=Generic STM32F407V series
@@ -282,6 +301,12 @@ generic_f407v.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 generic_f407v.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 generic_f407v.menu.rtlib.full=Newlib Standard
 generic_f407v.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+generic_f407v.menu.tchain.xpack=xPack GCC 9 (default)
+generic_f407v.menu.tchain.eabi=Arm none eabi GCC
+generic_f407v.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+generic_f407v.menu.tchain.eabi.build.flags.ldspecs=
 
 ##############################################################
 generic_f407v_mini.name=Generic STM32F407V mini series
@@ -363,6 +388,12 @@ generic_f407v_mini.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u 
 generic_f407v_mini.menu.rtlib.full=Newlib Standard
 generic_f407v_mini.menu.rtlib.full.build.flags.ldspecs=
 
+# Toolchain
+generic_f407v_mini.menu.tchain.xpack=xPack GCC 9 (default)
+generic_f407v_mini.menu.tchain.eabi=Arm none eabi GCC
+generic_f407v_mini.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+generic_f407v_mini.menu.tchain.eabi.build.flags.ldspecs=
+
 ##############################################################
 arch_max.name=Seeed Arch Max 1.1
 
@@ -436,6 +467,12 @@ arch_max.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 arch_max.menu.rtlib.nanofps.build.flags.ldspecs=--specs=nano.specs -u _printf_float -u _scanf_float
 arch_max.menu.rtlib.full=Newlib Standard
 arch_max.menu.rtlib.full.build.flags.ldspecs=
+
+# Toolchain
+arch_max.menu.tchain.xpack=xPack GCC 9 (default)
+arch_max.menu.tchain.eabi=Arm none eabi GCC
+arch_max.menu.tchain.eabi.compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+arch_max.menu.tchain.eabi.build.flags.ldspecs=
 
 ##############################################################
 

--- a/STM32F4/platform.txt
+++ b/STM32F4/platform.txt
@@ -8,7 +8,7 @@ version=0.1.0
 
 # compiler variables
 # ----------------------
-compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+compiler.path={runtime.tools.xpack-arm-none-eabi-gcc-9.2.1-1.1.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-c -g {build.flags.optimize} -Wall -MMD -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DERROR_LED_PIN={build.error_led_pin}
 compiler.c.elf.cmd=arm-none-eabi-g++
@@ -36,7 +36,7 @@ build.hs_flag=
 build.common_flags=-mthumb -D__STM32F4__ -DSTM32F4
 build.extra_flags= {build.cpu_flags} {build.hs_flag} {build.common_flags}
 build.flags.optimize=-Os
-build.flags.ldspecs=
+build.flags.ldspecs=--specs=nano.specs
 
 # These can be overridden in platform.local.txt
 compiler.c.extra_flags=


### PR DESCRIPTION
New toolchain: Updated "platform.txt"  to use the xpack gcc 9 toolchain; Added an extra option to choose between different runtime libraries in "boards.txt".

Issue: https://github.com/rogerclarkmelbourne/Arduino_STM32/issues/786