### PR TITLE
Prevent min and max macro definitions from colliding with the stdlib ones.

### DIFF
--- a/STM32F1/cores/maple/wirish_math.h
+++ b/STM32F1/cores/maple/wirish_math.h
@@ -105,8 +105,21 @@ long random(long min, long max);
 #define SERIAL  0x0
 #define DISPLAY 0x1 
 
-#define min(a,b)                ((a)<(b)?(a):(b))
-#define max(a,b)                ((a)>(b)?(a):(b))
+#ifdef __cplusplus
+	#include <algorithm>
+	using std::min;
+	using std::max;
+#else // C
+	#include <stdlib.h>
+	#ifndef min
+		#define min(a,b) ((a)<(b)?(a):(b))
+	#endif // min
+
+	#ifndef max
+		#define max(a,b) ((a)>(b)?(a):(b))
+	#endif // max
+#endif // __cplusplus
+
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define round(x)                ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #define radians(deg)            ((deg)*DEG_TO_RAD)

--- a/STM32F4/cores/maple/wirish_math.h
+++ b/STM32F4/cores/maple/wirish_math.h
@@ -91,8 +91,21 @@ long random(long min, long max);
 #define DEG_TO_RAD  0.017453292519943295769236907684886
 #define RAD_TO_DEG 57.295779513082320876798154814105
 
-#define min(a,b)                ((a)<(b)?(a):(b))
-#define max(a,b)                ((a)>(b)?(a):(b))
+#ifdef __cplusplus
+	#include <algorithm>
+	using std::min;
+	using std::max;
+#else // C
+	#include <stdlib.h>
+	#ifndef min
+		#define min(a,b) ((a)<(b)?(a):(b))
+	#endif // min
+
+	#ifndef max
+		#define max(a,b) ((a)>(b)?(a):(b))
+	#endif // max
+#endif // __cplusplus
+
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define round(x)                ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #define radians(deg)            ((deg)*DEG_TO_RAD)


### PR DESCRIPTION
Fixing issue https://github.com/rogerclarkmelbourne/Arduino_STM32/issues/788