### PR TITLE
Fix Java PATH problem on Windows (Fix Issue #813)

### DIFF
--- a/STM32F1/platform.txt
+++ b/STM32F1/platform.txt
@@ -118,7 +118,7 @@ tools.maple_upload.path.linux={runtime.hardware.path}/tools/linux
 tools.maple_upload.path.linux64={runtime.hardware.path}/tools/linux64    
 tools.maple_upload.upload.params.verbose=-d
 tools.maple_upload.upload.params.quiet=
-tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin"
+tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin" "{runtime.ide.path}"
 
 #Added tool for generic STM32 upload via serial to Serial Port 1 (pins PA9 and PA10) - note. Boot0 line needs to high on board reset to enable upload via serial
 # at the end up the upload the program is automatically run, without the board being reset

--- a/tools/win/maple_upload.bat
+++ b/tools/win/maple_upload.bat
@@ -5,6 +5,7 @@ set driverLetter=%~dp0
 set driverLetter=%driverLetter:~0,2%
 %driverLetter%
 cd %~dp0
+if exist "C:\Program Files (x86)\Arduino\java\bin" set PATH=C:\Program Files (x86)\Arduino\java\bin;%PATH%
 java -jar maple_loader.jar %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 for /l %%x in (1, 1, 40) do (

--- a/tools/win/maple_upload.bat
+++ b/tools/win/maple_upload.bat
@@ -5,8 +5,8 @@ set driverLetter=%~dp0
 set driverLetter=%driverLetter:~0,2%
 %driverLetter%
 cd %~dp0
-if exist "C:\Program Files (x86)\Arduino\java\bin" set PATH=C:\Program Files (x86)\Arduino\java\bin;%PATH%
-java -jar maple_loader.jar %1 %2 %3 %4 %5 %6 %7 %8 %9
+set PATH=%5\java\bin;%PATH%
+java -jar maple_loader.jar %1 %2 %3 %4
 
 for /l %%x in (1, 1, 40) do (
   ping -w 50 -n 1 192.0.2.1 > nul


### PR DESCRIPTION
This solves the problem where this batch file may use a different Java version compared to the one provided by the Arduino IDE. 
(see Issue #813)