### PR TITLE
Fix "unknown type uint8_t" error

### DIFF
--- a/STM32F1/cores/maple/avr/dtostrf.c
+++ b/STM32F1/cores/maple/avr/dtostrf.c
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
+
 
 char *dtostrf(double val, signed char width, unsigned char prec, char *sout)
 {


### PR DESCRIPTION
Added missing include to "inttypes.h"