### PR TITLE
Adafruit_ILI9341_STM (stm32f1): Allow user to force the use of DMA.

### DIFF
--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
@@ -276,17 +276,16 @@ void Adafruit_ILI9341_STM::drawFastVLine(int16_t x, int16_t y, int16_t h,
 
   setAddrWindow(x, y, x, y + h - 1);
 
-#if ILI9341_STM_DMA_ON_LIMIT != 0
-  if (h>ILI9341_STM_DMA_ON_LIMIT) {
-#endif
+#ifndef ILI9341_STM_FORCEDMA
+  if (h>DMA_ON_LIMIT) {
+#endif   
     lineBuffer[0] = color;
     mSPI.dmaSend(lineBuffer, h, 0);
-#if ILI9341_STM_DMA_ON_LIMIT != 0
+#ifndef ILI9341_STM_FORCEDMA
   } else {
     mSPI.write(color, h);
   }
 #endif
-  
   cs_set();
 }
 
@@ -304,17 +303,16 @@ void Adafruit_ILI9341_STM::drawFastHLine(int16_t x, int16_t y, int16_t w,
 
   setAddrWindow(x, y, x + w - 1, y);
 
-#if ILI9341_STM_DMA_ON_LIMIT != 0
-  if (w>ILI9341_STM_DMA_ON_LIMIT) {
+#ifndef ILI9341_STM_FORCEDMA
+  if (w>DMA_ON_LIMIT) {
 #endif
     lineBuffer[0] = color;
     mSPI.dmaSend(lineBuffer, w, 0);
-#if ILI9341_STM_DMA_ON_LIMIT != 0
+#ifndef ILI9341_STM_FORCEDMA
   } else {
     mSPI.write(color, w);
   }
 #endif
-  
   cs_set();
 }
 
@@ -347,20 +345,19 @@ void Adafruit_ILI9341_STM::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 
   setAddrWindow(x, y, x + w - 1, y + h - 1);
   uint32_t nr_bytes = w * h;
-#if ILI9341_STM_DMA_ON_LIMIT != 0
-  if ( nr_bytes>ILI9341_STM_DMA_ON_LIMIT ) {
+#ifndef ILI9341_STM_FORCEDMA
+  if ( nr_bytes>DMA_ON_LIMIT ) {
 #endif
     while ( nr_bytes>65535 ) {
       nr_bytes -= 65535;
       mSPI.dmaSend(lineBuffer, (65535), 0);
     }
     mSPI.dmaSend(lineBuffer, nr_bytes, 0);
-#if ILI9341_STM_DMA_ON_LIMIT != 0
+#ifndef ILI9341_STM_FORCEDMA
   } else {
     mSPI.write(color, nr_bytes);
   }
 #endif
-  
   cs_set();
 }
 

--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
@@ -276,16 +276,12 @@ void Adafruit_ILI9341_STM::drawFastVLine(int16_t x, int16_t y, int16_t h,
 
   setAddrWindow(x, y, x, y + h - 1);
 
-#ifndef ILI9341_STM_FORCEDMA
-  if (h>DMA_ON_LIMIT) {
-#endif   
+  if (h>ILI9341_STM_DMA_ON_LIMIT) {
     lineBuffer[0] = color;
     mSPI.dmaSend(lineBuffer, h, 0);
-#ifndef ILI9341_STM_FORCEDMA
   } else {
     mSPI.write(color, h);
   }
-#endif
   cs_set();
 }
 
@@ -303,16 +299,12 @@ void Adafruit_ILI9341_STM::drawFastHLine(int16_t x, int16_t y, int16_t w,
 
   setAddrWindow(x, y, x + w - 1, y);
 
-#ifndef ILI9341_STM_FORCEDMA
-  if (w>DMA_ON_LIMIT) {
-#endif
+  if (w>ILI9341_STM_DMA_ON_LIMIT) {
     lineBuffer[0] = color;
     mSPI.dmaSend(lineBuffer, w, 0);
-#ifndef ILI9341_STM_FORCEDMA
   } else {
     mSPI.write(color, w);
   }
-#endif
   cs_set();
 }
 
@@ -345,19 +337,15 @@ void Adafruit_ILI9341_STM::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 
   setAddrWindow(x, y, x + w - 1, y + h - 1);
   uint32_t nr_bytes = w * h;
-#ifndef ILI9341_STM_FORCEDMA
-  if ( nr_bytes>DMA_ON_LIMIT ) {
-#endif
+  if ( nr_bytes>ILI9341_STM_DMA_ON_LIMIT ) {
     while ( nr_bytes>65535 ) {
       nr_bytes -= 65535;
       mSPI.dmaSend(lineBuffer, (65535), 0);
     }
     mSPI.dmaSend(lineBuffer, nr_bytes, 0);
-#ifndef ILI9341_STM_FORCEDMA
   } else {
     mSPI.write(color, nr_bytes);
   }
-#endif
   cs_set();
 }
 

--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.cpp
@@ -276,12 +276,17 @@ void Adafruit_ILI9341_STM::drawFastVLine(int16_t x, int16_t y, int16_t h,
 
   setAddrWindow(x, y, x, y + h - 1);
 
-  if (h>DMA_ON_LIMIT) {
+#if ILI9341_STM_DMA_ON_LIMIT != 0
+  if (h>ILI9341_STM_DMA_ON_LIMIT) {
+#endif
     lineBuffer[0] = color;
     mSPI.dmaSend(lineBuffer, h, 0);
+#if ILI9341_STM_DMA_ON_LIMIT != 0
   } else {
     mSPI.write(color, h);
   }
+#endif
+  
   cs_set();
 }
 
@@ -299,12 +304,17 @@ void Adafruit_ILI9341_STM::drawFastHLine(int16_t x, int16_t y, int16_t w,
 
   setAddrWindow(x, y, x + w - 1, y);
 
-  if (w>DMA_ON_LIMIT) {
+#if ILI9341_STM_DMA_ON_LIMIT != 0
+  if (w>ILI9341_STM_DMA_ON_LIMIT) {
+#endif
     lineBuffer[0] = color;
     mSPI.dmaSend(lineBuffer, w, 0);
+#if ILI9341_STM_DMA_ON_LIMIT != 0
   } else {
     mSPI.write(color, w);
   }
+#endif
+  
   cs_set();
 }
 
@@ -337,15 +347,20 @@ void Adafruit_ILI9341_STM::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 
   setAddrWindow(x, y, x + w - 1, y + h - 1);
   uint32_t nr_bytes = w * h;
-  if ( nr_bytes>DMA_ON_LIMIT ) {
+#if ILI9341_STM_DMA_ON_LIMIT != 0
+  if ( nr_bytes>ILI9341_STM_DMA_ON_LIMIT ) {
+#endif
     while ( nr_bytes>65535 ) {
       nr_bytes -= 65535;
       mSPI.dmaSend(lineBuffer, (65535), 0);
     }
     mSPI.dmaSend(lineBuffer, nr_bytes, 0);
+#if ILI9341_STM_DMA_ON_LIMIT != 0
   } else {
     mSPI.write(color, nr_bytes);
   }
+#endif
+  
   cs_set();
 }
 

--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
@@ -128,7 +128,10 @@ class Adafruit_ILI9341_STM : public Adafruit_GFX_AS {
   uint32_t readcommand32(uint8_t);
   */
 
-#define DMA_ON_LIMIT 250 // do DMA only for more data than this
+#ifndef ILI9341_STM_DMA_ON_LIMIT
+#define ILI9341_STM_DMA_ON_LIMIT 250 // do DMA only for more data than this
+#endif
+
 #define SAFE_FREQ  24000000ul // 24MHz for reading
 
 #define writePixel drawPixel

--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
@@ -128,9 +128,7 @@ class Adafruit_ILI9341_STM : public Adafruit_GFX_AS {
   uint32_t readcommand32(uint8_t);
   */
 
-#ifndef ILI9341_STM_DMA_ON_LIMIT
-#define ILI9341_STM_DMA_ON_LIMIT 250 // do DMA only for more data than this
-#endif
+#define DMA_ON_LIMIT 250 // do DMA only for more data than this
 
 #define SAFE_FREQ  24000000ul // 24MHz for reading
 

--- a/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
+++ b/STM32F1/libraries/Adafruit_ILI9341_STM/Adafruit_ILI9341_STM.h
@@ -129,7 +129,6 @@ class Adafruit_ILI9341_STM : public Adafruit_GFX_AS {
   */
 
 #define DMA_ON_LIMIT 250 // do DMA only for more data than this
-
 #define SAFE_FREQ  24000000ul // 24MHz for reading
 
 #define writePixel drawPixel


### PR DESCRIPTION
After switching from an older version of this library, I noticed some drawing code was running a lot more slowly. After some testing, I narrowed it down to the behaviour of DMA_ON_LIMIT. It seems like, in at least some cases, the current setting can result in a big slowdown: in my tests on an STM32F103C8T6 'blue pill' board, I got the following results:

- With DMA_ON_LIMIT as is, calls to drawFastVLine took an average of 260 microseconds.
- With the conditionals on DMA_ON_LIMIT commented out (so that it would always use DMA), calls to drawFastVLine took an average of 160 microseconds.

This adds up: when you're trying to call the function 2000+ times per second (e.g., to draw out a waveform on screen in something approaching realtime), it makes a big difference.

**This pull request makes the following changes:**
- Renames DMA_ON_LIMIT to ILI9341_STM_DMA_ON_LIMIT.
- Uses preprocessor guards to permit the user to change the value of ILI9341_STM_DMA_ON_LIMIT.
- Uses preprocessor conditionals to omit the non-DMA case entirely (and always use DMA) if the user has defined ILI9341_STM_DMA_ON_LIMIT as 0.