### PR TITLE
Adafruit_ILI9341_STM (stm32f1): Compatibility with current HEAD versions of Adafruit GFX

### DIFF
--- a/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.cpp
+++ b/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.cpp
@@ -139,14 +139,14 @@ byte line = 0;
 for(int16_t i=0; i<height; i++)
 {
   if (textcolor != textbgcolor) {
-    if (textsize == 1) drawFastHLine(x, pY, width+gap, textbgcolor);
-    else fillRect(x, pY, (width+gap)*textsize, textsize, textbgcolor);
+    if (textsize_x == 1) drawFastHLine(x, pY, width+gap, textbgcolor);
+    else fillRect(x, pY, (width+gap)*textsize_x, textsize_x, textbgcolor);
   }
   for (int16_t k = 0;k < w; k++)
   { 
     line = pgm_read_byte(flash_address+w*i+k);
     if(line) {
-      if (textsize==1){
+      if (textsize_x==1){
         pX = x + k*8;
         if(line & 0x80) drawPixel(pX, pY, textcolor);
         if(line & 0x40) drawPixel(pX+1, pY, textcolor);
@@ -158,21 +158,21 @@ for(int16_t i=0; i<height; i++)
         if(line & 0x1) drawPixel(pX+7, pY, textcolor);
       }
        else {
-        pX = x + k*8*textsize;
-        if(line & 0x80) fillRect(pX, pY, textsize, textsize, textcolor);
-        if(line & 0x40) fillRect(pX+textsize, pY, textsize, textsize, textcolor);
-        if(line & 0x20) fillRect(pX+2*textsize, pY, textsize, textsize, textcolor);
-        if(line & 0x10) fillRect(pX+3*textsize, pY, textsize, textsize, textcolor);
-        if(line & 0x8) fillRect(pX+4*textsize, pY, textsize, textsize, textcolor);
-        if(line & 0x4) fillRect(pX+5*textsize, pY, textsize, textsize, textcolor);
-        if(line & 0x2) fillRect(pX+6*textsize, pY, textsize, textsize, textcolor);
-        if(line & 0x1) fillRect(pX+7*textsize, pY, textsize, textsize, textcolor);
+        pX = x + k*8*textsize_x;
+        if(line & 0x80) fillRect(pX, pY, textsize_x, textsize_x, textcolor);
+        if(line & 0x40) fillRect(pX+textsize_x, pY, textsize_x, textsize_x, textcolor);
+        if(line & 0x20) fillRect(pX+2*textsize_x, pY, textsize_x, textsize_x, textcolor);
+        if(line & 0x10) fillRect(pX+3*textsize_x, pY, textsize_x, textsize_x, textcolor);
+        if(line & 0x8) fillRect(pX+4*textsize_x, pY, textsize_x, textsize_x, textcolor);
+        if(line & 0x4) fillRect(pX+5*textsize_x, pY, textsize_x, textsize_x, textcolor);
+        if(line & 0x2) fillRect(pX+6*textsize_x, pY, textsize_x, textsize_x, textcolor);
+        if(line & 0x1) fillRect(pX+7*textsize_x, pY, textsize_x, textsize_x, textcolor);
       }
     }
   }
-  pY+=textsize;
+  pY+=textsize_x;
 }
-return (width+gap)*textsize;        // x +
+return (width+gap)*textsize_x;        // x +
 }
 
 /***************************************************************************************
@@ -246,7 +246,7 @@ int16_t Adafruit_GFX_AS::drawCentreString(char *string, int16_t dX, int16_t poY,
 #endif
         *pointer++;
     }
-    len = len*textsize;
+    len = len*textsize_x;
     int16_t poX = dX - len/2;
 
     if (poX < 0) poX = 0;
@@ -297,7 +297,7 @@ int16_t Adafruit_GFX_AS::drawRightString(char *string, int16_t dX, int16_t poY, 
         *pointer++;
     }
     
-    len = len*textsize;
+    len = len*textsize_x;
     int16_t poX = dX - len;
 
     if (poX < 0) poX = 0;

--- a/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.cpp
+++ b/STM32F1/libraries/Adafruit_GFX_AS/Adafruit_GFX_AS.cpp
@@ -59,6 +59,8 @@ POSSIBILITY OF SUCH DAMAGE.
  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #endif
 
+#define textsize textsize_x
+
 Adafruit_GFX_AS::Adafruit_GFX_AS(int16_t w, int16_t h): Adafruit_GFX(w, h)
 {
 }
@@ -139,14 +141,14 @@ byte line = 0;
 for(int16_t i=0; i<height; i++)
 {
   if (textcolor != textbgcolor) {
-    if (textsize_x == 1) drawFastHLine(x, pY, width+gap, textbgcolor);
-    else fillRect(x, pY, (width+gap)*textsize_x, textsize_x, textbgcolor);
+    if (textsize == 1) drawFastHLine(x, pY, width+gap, textbgcolor);
+    else fillRect(x, pY, (width+gap)*textsize, textsize, textbgcolor);
   }
   for (int16_t k = 0;k < w; k++)
   { 
     line = pgm_read_byte(flash_address+w*i+k);
     if(line) {
-      if (textsize_x==1){
+      if (textsize==1){
         pX = x + k*8;
         if(line & 0x80) drawPixel(pX, pY, textcolor);
         if(line & 0x40) drawPixel(pX+1, pY, textcolor);
@@ -158,21 +160,21 @@ for(int16_t i=0; i<height; i++)
         if(line & 0x1) drawPixel(pX+7, pY, textcolor);
       }
        else {
-        pX = x + k*8*textsize_x;
-        if(line & 0x80) fillRect(pX, pY, textsize_x, textsize_x, textcolor);
-        if(line & 0x40) fillRect(pX+textsize_x, pY, textsize_x, textsize_x, textcolor);
-        if(line & 0x20) fillRect(pX+2*textsize_x, pY, textsize_x, textsize_x, textcolor);
-        if(line & 0x10) fillRect(pX+3*textsize_x, pY, textsize_x, textsize_x, textcolor);
-        if(line & 0x8) fillRect(pX+4*textsize_x, pY, textsize_x, textsize_x, textcolor);
-        if(line & 0x4) fillRect(pX+5*textsize_x, pY, textsize_x, textsize_x, textcolor);
-        if(line & 0x2) fillRect(pX+6*textsize_x, pY, textsize_x, textsize_x, textcolor);
-        if(line & 0x1) fillRect(pX+7*textsize_x, pY, textsize_x, textsize_x, textcolor);
+        pX = x + k*8*textsize;
+        if(line & 0x80) fillRect(pX, pY, textsize, textsize, textcolor);
+        if(line & 0x40) fillRect(pX+textsize, pY, textsize, textsize, textcolor);
+        if(line & 0x20) fillRect(pX+2*textsize, pY, textsize, textsize, textcolor);
+        if(line & 0x10) fillRect(pX+3*textsize, pY, textsize, textsize, textcolor);
+        if(line & 0x8) fillRect(pX+4*textsize, pY, textsize, textsize, textcolor);
+        if(line & 0x4) fillRect(pX+5*textsize, pY, textsize, textsize, textcolor);
+        if(line & 0x2) fillRect(pX+6*textsize, pY, textsize, textsize, textcolor);
+        if(line & 0x1) fillRect(pX+7*textsize, pY, textsize, textsize, textcolor);
       }
     }
   }
-  pY+=textsize_x;
+  pY+=textsize;
 }
-return (width+gap)*textsize_x;        // x +
+return (width+gap)*textsize;        // x +
 }
 
 /***************************************************************************************
@@ -246,7 +248,7 @@ int16_t Adafruit_GFX_AS::drawCentreString(char *string, int16_t dX, int16_t poY,
 #endif
         *pointer++;
     }
-    len = len*textsize_x;
+    len = len*textsize;
     int16_t poX = dX - len/2;
 
     if (poX < 0) poX = 0;
@@ -297,7 +299,7 @@ int16_t Adafruit_GFX_AS::drawRightString(char *string, int16_t dX, int16_t poY, 
         *pointer++;
     }
     
-    len = len*textsize_x;
+    len = len*textsize;
     int16_t poX = dX - len;
 
     if (poX < 0) poX = 0;
@@ -377,3 +379,5 @@ int16_t Adafruit_GFX_AS::drawFloat(float floatNumber, int16_t decimal, int16_t p
     }
     return sumX;
 }
+
+#undef textsize

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -277,7 +277,7 @@ public:
     // Some libraries (like recent Adafruit graphics libraries) require
     // the write function be availabe under the name transfer, so here it is:
     inline void transfer(const void * buffer, size_t length) {
-     write((uint32_t)buffer, length);
+     write(buffer, (uint32)length);
     }
  
     /**

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -274,6 +274,12 @@ public:
      */
     void write(const void * buffer, uint32 length);
 
+    // Some libraries (like recent Adafruit graphics libraries) require
+    // the write function be availabe under the name transfer, so here it is:
+    inline void transfer(const void * buffer, size_t length) {
+     write((uint32_t)buffer, length);
+    }
+ 
     /**
      * @brief Transmit a byte, then return the next unread byte.
      *


### PR DESCRIPTION
The ILI9341 has depended on a fairly ancient (1.5.3) version of the Adafruit GFX Library. 

This commit makes it compatible with the current HEAD versions of the Adafruit GFX Library by making the following two changes:

- Update references to use textsize_x (renamed in version 1.5.4 of the graphics library) when calculating positions/sizes in Adafruit_GFX_AS.cpp.
- Provides the SPIClass::transfer(...) method expected by Adafruit BusIO's SPIDevice class.