### PR TITLE
SPI: add parameter to spiclass::on transmit/on receive

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.cpp
+++ b/STM32F1/libraries/SPI/src/SPI.cpp
@@ -565,8 +565,9 @@ uint8 SPIClass::dmaSendAsync(const void * transmitBuf, uint16 length, bool minc)
     Victor Perez 2017
 */
 
-void SPIClass::onReceive(void(*callback)(void)) {
+void SPIClass::onReceive(void(*callback)(void *),void *cookie) {
     _currentSetting->receiveCallback = callback;
+    _currentSetting->receiveCookie = cookie;
     if (callback){
         switch (_currentSetting->spi_d->clk_id) {
             #if BOARD_NR_SPI >= 1
@@ -593,8 +594,9 @@ void SPIClass::onReceive(void(*callback)(void)) {
     }
 }
 
-void SPIClass::onTransmit(void(*callback)(void)) {
+void SPIClass::onTransmit(void(*callback)(void *),void *cookie) {
     _currentSetting->transmitCallback = callback;
+    _currentSetting->transmitCookie = cookie;
     if (callback){
         switch (_currentSetting->spi_d->clk_id) {
             #if BOARD_NR_SPI >= 1
@@ -639,7 +641,7 @@ void SPIClass::EventCallback() {
 
         if (_currentSetting->receiveCallback)
         {
-            _currentSetting->receiveCallback();
+            _currentSetting->receiveCallback(_currentSetting->receiveCookie);
         }
         break;
     case SPI_STATE_TRANSMIT:
@@ -648,7 +650,7 @@ void SPIClass::EventCallback() {
         //dma_disable(_currentSetting->spiDmaDev, _currentSetting->spiTxDmaChannel);
         if (_currentSetting->transmitCallback)
         {
-            _currentSetting->transmitCallback();
+            _currentSetting->transmitCallback(_currentSetting->transmitCookie);
         }
 
         break;

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -150,9 +150,10 @@ private:
 	spi_dev *spi_d;
 	dma_channel spiRxDmaChannel, spiTxDmaChannel;
 	dma_dev* spiDmaDev;
-  void (*receiveCallback)(void) = NULL;
-  void (*transmitCallback)(void) = NULL;
-	
+        void (*receiveCallback)(void *) = NULL;
+        void (*transmitCallback)(void *) = NULL;
+        void *receiveCookie=NULL;
+        void *transmitCookie=NULL;
 	friend class SPIClass;
 };
 
@@ -230,8 +231,8 @@ public:
 	* onTransmit used to set the callback in case of dmaSend (tx only). That function
 	* will NOT be called in case of TX/RX
     */
-    void onReceive(void(*)(void));
-    void onTransmit(void(*)(void));
+    void onReceive(void(*)(void *),void *cookie=NULL);
+    void onTransmit(void(*)(void *), void *cookie=NULL);
 
     /*
      * I/O


### PR DESCRIPTION
This PR adds a parameter/cookie to the spi class onTransmit/onReceive callbacks
This is useful to go back to the client class when the callback is invoked 
By default the parameter is null, so it should be compatible with the current API

It is especially useful when using a small RTOS like FreeRTOS

To give an example,  a transfer to the screen is armed and the task waits on a semaphore
The callback cookie is actually the client instance, and upon dereferencing, the semaphore is unlocked

i.e. 
static void Screen::screencallback(void * a) { myScreen *s=(Screen *)a; s->transferDone();}


