### PR TITLE
Fixed bug in composite_cdcacm_peek_ex

### DIFF
--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -494,7 +494,7 @@ uint32 usb_cdcacm_peek(uint8* buf, uint32 len)
 {
     uint32 i;
     uint32 tail = rx_tail;
-	uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+    uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len > rx_unread) {
         len = rx_unread;
@@ -512,10 +512,10 @@ uint32 usb_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
     uint32 i;
     uint32 tail = (rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
-	uint32 rx_unread = (rx_head-rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+    uint32 rx_unread = (rx_head-rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
-    if (len + offset > rx_unread) {
-        len = rx_unread - offset;
+    if (len > rx_unread) {
+        len = rx_unread;
     }
 
     for (i = 0; i < len; i++) {

--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -512,7 +512,7 @@ uint32 usb_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
     uint32 i;
     uint32 tail = (rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
-	uint32 rx_unread = (rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	uint32 rx_unread = (rx_head-rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len + offset > rx_unread) {
         len = rx_unread - offset;

--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -512,7 +512,7 @@ uint32 usb_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
     uint32 i;
     uint32 tail = (rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
-    uint32 rx_unread = (rx_head-rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+    uint32 rx_unread = (rx_head - tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len > rx_unread) {
         len = rx_unread;

--- a/STM32F1/libraries/USBComposite/usb_composite_serial.c
+++ b/STM32F1/libraries/USBComposite/usb_composite_serial.c
@@ -395,7 +395,7 @@ uint32 composite_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
     unsigned i;
     uint32 tail = (vcom_rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
-    uint32 rx_unread = (vcom_rx_head-vcom_rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+    uint32 rx_unread = (vcom_rx_head - tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len > rx_unread) {
         len = rx_unread;

--- a/STM32F1/libraries/USBComposite/usb_composite_serial.c
+++ b/STM32F1/libraries/USBComposite/usb_composite_serial.c
@@ -377,7 +377,7 @@ uint32 composite_cdcacm_peek(uint8* buf, uint32 len)
 {
     unsigned i;
     uint32 tail = vcom_rx_tail;
-	uint32 rx_unread = (vcom_rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+    uint32 rx_unread = (vcom_rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len > rx_unread) {
         len = rx_unread;
@@ -395,10 +395,10 @@ uint32 composite_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
     unsigned i;
     uint32 tail = (vcom_rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
-	uint32 rx_unread = (vcom_rx_head-vcom_rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+    uint32 rx_unread = (vcom_rx_head-vcom_rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
-    if (len + offset > rx_unread) {
-        len = rx_unread - offset;
+    if (len > rx_unread) {
+        len = rx_unread;
     }
 
     for (i = 0; i < len; i++) {

--- a/STM32F1/libraries/USBComposite/usb_composite_serial.c
+++ b/STM32F1/libraries/USBComposite/usb_composite_serial.c
@@ -395,7 +395,7 @@ uint32 composite_cdcacm_peek_ex(uint8* buf, uint32 offset, uint32 len)
 {
     unsigned i;
     uint32 tail = (vcom_rx_tail + offset) & CDC_SERIAL_RX_BUFFER_SIZE_MASK ;
-	uint32 rx_unread = (vcom_rx_head-tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
+	uint32 rx_unread = (vcom_rx_head-vcom_rx_tail) & CDC_SERIAL_RX_BUFFER_SIZE_MASK;
 
     if (len + offset > rx_unread) {
         len = rx_unread - offset;


### PR DESCRIPTION
Fixed bug in composite_cdcacm_peek_ex.

rx_unread was calculated incorrectly in case offset>0. The too low rx_unread leads to len being set to a very high number in the next lines, causing the software to crash.