### PR TITLE
STM32F4 backup domain registers and backup domain sram

### DIFF
--- a/STM32F4/cores/maple/libmaple/rccF4.h
+++ b/STM32F4/cores/maple/libmaple/rccF4.h
@@ -326,6 +326,7 @@ typedef struct
 
 /* AHB peripheral clock enable register */
 
+#define RCC_AHB1ENR_BKPSRAMEN_BIT       18
 #define RCC_AHBENR_SDIOEN_BIT           10
 #define RCC_AHBENR_FSMCEN_BIT           8
 #define RCC_AHBENR_CRCEN_BIT            7
@@ -334,6 +335,7 @@ typedef struct
 #define RCC_AHBENR_DMA2EN_BIT           1
 #define RCC_AHBENR_DMA1EN_BIT           0
 
+#define RCC_AHB1ENR_BKPSRAMEN   		BIT(RCC_AHB1ENR_BKPSRAMEN_BIT)
 #define RCC_AHBENR_SDIOEN               BIT(RCC_AHBENR_SDIOEN_BIT)
 #define RCC_AHBENR_FSMCEN               BIT(RCC_AHBENR_FSMCEN_BIT)
 #define RCC_AHBENR_CRCEN                BIT(RCC_AHBENR_CRCEN_BIT)

--- a/STM32F4/libraries/RTClock/examples/BkpTest/BkpTest.ino
+++ b/STM32F4/libraries/RTClock/examples/BkpTest/BkpTest.ino
@@ -1,0 +1,150 @@
+#include <RTClock.h>
+
+#include <Arduino.h>
+#include <RTClock.h>
+#include <usb_serial.h>
+#include <libmaple/bkp.h>
+#include <string.h>
+
+RTClock rt; // initialise
+
+void setbkpvalues();
+void readbkpvalues();
+void sleep(uint16_t dur);
+
+int ledPin = BOARD_LED_PIN;
+
+// the setup() method runs once when the sketch starts
+void setup() {
+
+	pinMode(ledPin, OUTPUT);
+	digitalWrite(ledPin, LOW); //turn on the led
+
+	Serial.begin();
+	//wait for keypress
+	while(!Serial.available()) sleep(1);
+	while(Serial.available()) Serial.read();
+
+	Serial.println("init");
+
+	// enable backup domain clock
+	bkp_init();
+	/* enable backup sram
+	 * bkp_init() needs to be called prior
+	 * passing true enable the backup power regulator, runs on VBAT e.g. coin cell
+	 * passing false BKPSRAM is lost if VDD is lost, but preserves across a reset
+	 * if only backup sram is used rt.begin() can be skipped, but bkp_init() need to be called prior
+	 */
+	bkp_initsram(false);
+	// setup RTClock,
+	// note that an initialized RTClock is necessary to access backup registers.
+	// if only backup registers are accessed, bkp_initsram() can be skipped
+	rt.begin();
+
+	Serial.println("bkp values:");
+	readbkpvalues();
+	Serial.flush();
+	sleep(500);
+
+	Serial.println("setting bkp values:");
+	Serial.flush();
+	setbkpvalues();
+	sleep(500);
+
+	Serial.println("bkp values:");
+	readbkpvalues();
+	Serial.flush();
+
+	digitalWrite(ledPin, !digitalRead(ledPin));
+}
+
+//the loop() method runs over and over again, 
+//as long as maple has power
+void loop() {
+	sleep(1000);
+}
+
+void setbkpvalues() {
+	const char *text = (const char*)F("a quick brown fox jumps over the lazy dog");
+
+	// before writing to bkp registers it is necessary to enable writes
+	// or it will hardfault / freeze
+	bkp_enable_writes();
+	// set values in backup registers
+	// write values 1000001 .. 1000020 in backup registers
+	for (uint8_t r=1; r<=20; r++) {
+		bkp_write(r, 100000 + r);
+	}
+	bkp_disable_writes();
+
+	// check if BKPSRAM is enabled, if not skip writing them
+	if(!(RCC->AHB1ENR & RCC_AHB1ENR_BKPSRAMEN))
+		return;
+
+	//before writing to bkpsram it is necessary to enable writes
+	// or it will hardfault / freeze
+	bkp_enable_writes();
+	//clear bkp sram
+	bkpsram_clear();
+
+	// write 100 in 2nd byte in BKP_SRAM
+	bkp_sramwrite8(1, 100);
+
+	// write 10000 in 2nd uint16_t word in BKP_SRAM
+	bkp_sramwrite16(1, 10000);
+
+	// write 1000000 in 2nd uint32_t word in BKP_SRAM
+	bkp_sramwrite32(1, 1000000);
+
+	//write text in BKPSRAM at offset 10
+	bkp_sramwrite(10, (uint8_t *)text, 41);
+	bkp_disable_writes();
+
+}
+
+void readbkpvalues() {
+	char buf[50];
+
+	// read backup registers
+	for (uint8_t r=1; r<=20; r++) {
+		uint32_t v = bkp_read(r);
+		Serial.print("reg :");
+		Serial.print(r);
+		Serial.print(':');
+		Serial.println(v);
+	}
+
+	// check if BKPSRAM is enabled, if not skip reading them
+	if(!(RCC->AHB1ENR & RCC_AHB1ENR_BKPSRAMEN))
+		return;
+
+	uint32_t val = 0;
+	// read 100 in 2nd byte in BKP_SRAM
+	val = bkp_sramread8(1);
+	Serial.print("BKPSRAM 2nd byte:");
+	Serial.println(val);
+
+	// read 10000 in 2nd uint16_t word in BKP_SRAM
+	val = 0;
+	val = bkp_sramread16(1);
+	Serial.print("BKPSRAM 2nd uint16 word:");
+	Serial.println(val);
+
+	// read 1000000 in 2nd uint32_t word in BKP_SRAM
+	val = 0;
+	val = bkp_sramread32(1);
+	Serial.print("BKPSRAM 2nd uint32 word:");
+	Serial.println(val);
+
+	memset(buf, 0, 50);
+	memcpy(buf, bkp_sramread(10), 41);
+	Serial.print("BKPSRAM text at offset 10:");
+	Serial.println(buf);
+
+}
+
+void sleep(uint16_t dur) {
+	//sleep 1ms - wait for systick interrupt
+	for(uint16_t i=0; i<dur; i++)
+		asm("wfi");
+}

--- a/STM32F4/libraries/RTClock/examples/BkpTest/readme.md
+++ b/STM32F4/libraries/RTClock/examples/BkpTest/readme.md
@@ -1,0 +1,58 @@
+# STM32 F4 backup domain registers and backup domain sram
+
+STM32F4xx tend to have 20 backup domain registers. BPK sram is normally only available on the 'larger' 
+stm32f4xx mcus, normally 4KB. mcus like stm32f401, stm32f411 has only backup registers.
+
+## Enable writes before writing BKP registers and BKP sram
+
+Before writing to BKP registers or BKP sram  it is necessary to enable writes, 
+or it will hardfault / freeze e.g.
+
+```
+// BKP register
+bkp_enable_writes();
+bkp_write(1, 10);
+bkp_disable_writes();
+
+// BKP sram
+bkp_enable_writes();
+bkp_sramwrite8(1, 100);
+bkp_disable_writes();
+
+```
+Backup registers index starts at 1 ... 20 (normally).
+
+While BKP sram api offset start from zero, offset 0 is beginning of BKP sram.
+
+
+## Initialization - dependency on RTClock
+
+Using the bkp registers requires RTClock to be initialized. e.g.
+
+```
+RTClock rt;
+void setup() {
+    bkp_init();
+    rt.begin();
+    
+    bkp_enable_writes();
+    bkp_write(1, 100); //write 100 in bkp register 1
+    bkp_disable_writes();
+
+    int32_t regval = bkp_read(1); // read register 1
+}
+```
+
+To use bkp sram, it requires separate call to bkp_initsram() to enable it.
+passing true enable the backup power regulator, runs on VBAT e.g. coin cell.
+passing false in bkp_initsram(false), BKPSRAM is lost if VDD is lost,
+but preserves across a reset. e.g.
+
+```
+void setup() {
+     bkp_init();
+     bkp_initsram(true);
+     rt.begin();
+     ...
+}
+```

--- a/STM32F4/libraries/RTClock/src/RTClock.cpp
+++ b/STM32F4/libraries/RTClock/src/RTClock.cpp
@@ -145,7 +145,7 @@ void RTClock::begin(rtc_clk_src src, uint16 sync_presc, uint16 async_presc)
 		async_prescaler = prescalers[clk_src].as_presc;
 	}
 	PRINTF("sync_prescaler = %d, async_prescaler = %d\n", sync_prescaler, async_prescaler);
-	if(!lse_ison && RTCSEL_LSE) {
+	if(!lse_ison) {
 		rtc_enter_config_mode();
 		RTC->PRER = (uint32)(async_prescaler << 16) + sync_prescaler;
 		RTC->DR = 0x00002101; // reset value


### PR DESCRIPTION
STM32F4: update bkp.h, bkp.c add support for backup registers and backup sram.
added example in STM32F4/libraries/RTClock/examples/BkpTest