### PR TITLE
fix maple_upload dfu_address set to {runtime.ide.path} instead of {up…

### DIFF
--- a/STM32F4/platform.txt
+++ b/STM32F4/platform.txt
@@ -111,7 +111,7 @@ tools.maple_upload.path.linux={runtime.hardware.path}/tools/linux
 tools.maple_upload.path.linux64={runtime.hardware.path}/tools/linux64
 tools.maple_upload.upload.params.verbose=-d
 tools.maple_upload.upload.params.quiet=
-tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin" {upload.dfuse_addr}
+tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin" "{runtime.ide.path}" {upload.dfuse_addr}
 
 # Generic STM32 upload via serial to Serial Port 1 (pins PA9 and PA10) - note. Boot0 line needs to high on board reset to enable upload via serial
 # at the end of the upload the program is automatically run, without the board being reset

--- a/tools/linux/maple_upload
+++ b/tools/linux/maple_upload
@@ -5,12 +5,12 @@
 
 
 if [ $# -lt 4 ]; then
-    echo "Usage: $0 $# <dummy_port> <altID> <usbID> <binfile>" >&2
+    echo "Usage: $0 $# <dummy_port> <altID> <usbID> <binfile> <path to ide> <dfuse address>" >&2
     exit 1
 fi
 dummy_port="$1"; altID="$2"; usbID="$3"; binfile="$4"; dummy_port_fullpath="/dev/$1"
-if [ $# -eq 5 ]; then
-    dfuse_addr="--dfuse-address $5"
+if [ $# -eq 6 ]; then
+    dfuse_addr="--dfuse-address $6"
 else
     dfuse_addr=""
 fi

--- a/tools/linux64/maple_upload
+++ b/tools/linux64/maple_upload
@@ -5,12 +5,12 @@
 
 
 if [ $# -lt 4 ]; then
-    echo "Usage: $0 $# <dummy_port> <altID> <usbID> <binfile>" >&2
+    echo "Usage: $0 $# <dummy_port> <altID> <usbID> <binfile> <path to ide> <dfuse address>" >&2
     exit 1
 fi
 dummy_port="$1"; altID="$2"; usbID="$3"; binfile="$4"; dummy_port_fullpath="/dev/$1"
-if [ $# -eq 5 ]; then
-    dfuse_addr="--dfuse-address $5"
+if [ $# -eq 6 ]; then
+    dfuse_addr="--dfuse-address $6"
 else
     dfuse_addr=""
 fi


### PR DESCRIPTION
…load.dfuse_addr} or nothing #854

fix #854 

tested with F1 only and only on 64bit linux, but it is simple fix 