### PR TITLE
Added build options to select HSI clock source - Generic F103C8

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -396,6 +396,15 @@ genericSTM32F103C.menu.upload_method.HIDUploadMethod.build.vect=VECT_TAB_ADDR=0x
 genericSTM32F103C.menu.upload_method.HIDUploadMethod.build.ldscript=ld/hid_bootloader.ld
 
 #-- CPU Clock frequency
+
+genericSTM32F103C.menu.cpu_speed.speed_hsi_64mhz=64Mhz (HSI)
+genericSTM32F103C.menu.cpu_speed.speed_hsi_64mhz.build.f_cpu=64000000L
+genericSTM32F103C.menu.cpu_speed.speed_hsi_64mhz.build.hs_flag=-DUSE_HSI_CLOCK
+
+genericSTM32F103C.menu.cpu_speed.speed_hsi_48mhz=48Mhz (HSI- USB) 
+genericSTM32F103C.menu.cpu_speed.speed_hsi_48mhz.build.f_cpu=48000000L
+genericSTM32F103C.menu.cpu_speed.speed_hsi_48mhz.build.hs_flag=-DUSE_HSI_CLOCK -DHSI_USB_SPEED
+
 genericSTM32F103C.menu.cpu_speed.speed_72mhz=72Mhz (Normal)
 genericSTM32F103C.menu.cpu_speed.speed_72mhz.build.f_cpu=72000000L
 

--- a/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
+++ b/STM32F1/variants/generic_stm32f103c/wirish/boards_setup.cpp
@@ -59,7 +59,11 @@
 		#define BOARD_RCC_PLLMUL RCC_PLLMUL_2
 	#endif
   #else
-	#define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+	#if !HSI_USB_SPEED
+	    #define BOARD_RCC_PLLMUL RCC_PLLMUL_16
+    #else
+	    #define BOARD_RCC_PLLMUL RCC_PLLMUL_12
+    #endif
   #endif
 #endif
 


### PR DESCRIPTION
I have tested this with a generic F103C8 without a crystal and it works fine along with USB, SPI, UART etc, I don't see any issues apart from maybe the obvious clock inaccuracy of the internal RC, but other than that this feature was pretty handy for me and I feel like it should've been there already. 