### PR TITLE
Fix "call to overloaded transfer() is ambiguous" issue

### DIFF
--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -276,9 +276,9 @@ public:
 
     // Some libraries (like recent Adafruit graphics libraries) require
     // the write function be availabe under the name transfer, so here it is:
-    inline void transfer(const void * buffer, size_t length) {
+    /*inline void transfer(const void * buffer, size_t length) {
      write(buffer, (uint32)length);
-    }
+    }*/
  
     /**
      * @brief Transmit a byte, then return the next unread byte.

--- a/STM32F1/libraries/SPI/src/SPI.h
+++ b/STM32F1/libraries/SPI/src/SPI.h
@@ -276,9 +276,9 @@ public:
 
     // Some libraries (like recent Adafruit graphics libraries) require
     // the write function be availabe under the name transfer, so here it is:
-    /*inline void transfer(const void * buffer, size_t length) {
+    inline void transfer(const void * buffer, uint32 length) {
      write(buffer, (uint32)length);
-    }*/
+    }
  
     /**
      * @brief Transmit a byte, then return the next unread byte.


### PR DESCRIPTION
Two overloaded `SPI.transfer()`methods in file `STM32F1/libraries/SPI/src/SPI.h`:
```
void transfer(const void * buffer, size_t length);

void transfer(uint8_t * trx_buf, uint32 len);
```
produces a "call is ambiguous" error if called as:
`spi.transfer(uint8*, size_t);`

Making the type of second parameter the same in both methods eliminates the error.

