### PR TITLE
Add return values to STM32F4 Wire.write() methods to be compatible with recent Adafruit libraries

### DIFF
--- a/STM32F4/libraries/Wire/WireBase.cpp
+++ b/STM32F4/libraries/Wire/WireBase.cpp
@@ -95,35 +95,55 @@ uint8 WireBase::requestFrom(int address, int numBytes) {
     return WireBase::requestFrom((uint8)address, numBytes);
 }
 
-void WireBase::write(uint8 value) {
+uint8 WireBase::requestFrom(int address, int numBytes, uint8 stop) {
+    UNUSED(stop);
+    return WireBase::requestFrom((uint8)address, numBytes);
+}
+
+uint WireBase::write(uint8 value) {
     if (tx_buf_idx == BUFFER_LENGTH) {
         tx_buf_overflow = true;
-        return;
+        return 0;
     }
     tx_buf[tx_buf_idx++] = value;
     itc_msg.length++;
+    return 1;
 }
 
-void WireBase::write(uint8* buf, int len) {
+uint WireBase::write(uint8* buf, int len) {
+    uint result = 0;
     for (uint8 i = 0; i < len; i++) {
-        write(buf[i]);
+        result += write(buf[i]);
     }
+    return result;
 }
 
-void WireBase::write(int value) {
-    write((uint8)value);
+uint WireBase::write(const uint8* buf, int len) {
+    uint result = 0;
+    for (uint8 i = 0; i < len; i++) {
+        uint8_t v = buf[i];
+        result += write(v);
+    }
+    return result;
 }
 
-void WireBase::write(int* buf, int len) {
-    write((uint8*)buf, (uint8)len);
+
+uint WireBase::write(int value) {
+    return write((uint8)value);
 }
 
-void WireBase::write(char* buf) {
+uint WireBase::write(int* buf, int len) {
+    return write((uint8*)buf, (uint8)len);
+}
+
+uint WireBase::write(char* buf) {
     uint8 *ptr = (uint8*)buf;
+    uint result = 0;
     while (*ptr) {
-        write(*ptr);
+        result +=  write(*ptr);
         ptr++;
     }
+     return result;
 }
 
 uint8 WireBase::available() {

--- a/STM32F4/libraries/Wire/WireBase.h
+++ b/STM32F4/libraries/Wire/WireBase.h
@@ -40,7 +40,7 @@
 
 #ifndef _WIREBASE_H_
 #define _WIREBASE_H_
-
+#define UNUSED(x) (void)x;
 #include "wirish.h"
 #include <libmaple/i2c.h>
 
@@ -99,36 +99,41 @@ public:
      * storing into the receiving buffer.
      */
     uint8 requestFrom(uint8, int);
-
+    
     /*
      * Allow only 8 bit addresses to be used when requesting bytes
      */
     uint8 requestFrom(int, int);
-
+    uint8 requestFrom(int, int, uint8);
     /*
      * Stack up bytes to be sent when transmitting
      */
-    void write(uint8);
+    uint write(uint8);
 
     /*
      * Stack up bytes from the array to be sent when transmitting
      */
-    void write(uint8*, int);
+    uint write(uint8*, int);
+
+    /*
+     * Stack up bytes from the array to be sent when transmitting
+     */
+    uint write(const uint8*, int);
 
     /*
      * Ensure that a sending data will only be 8-bit bytes
      */
-    void write(int);
+    uint write(int);
 
     /*
      * Ensure that an array sending data will only be 8-bit bytes
      */
-    void write(int*, int);
+    uint write(int*, int);
 
     /*
      * Stack up bytes from a string to be sent when transmitting
      */
-    void write(char*);
+    uint write(char*);
 
     /*
      * Return the amount of bytes that is currently in the receiving buffer


### PR DESCRIPTION
Methods `write()` of the WireBase class for STM32F4 (`STM32F4/libraries/Wire/WireBase.h`) are erroneously defined as void, which makes them incompatible with recent versions of libraries such as Adafruit GFx. The same methods in the branch for STM32F1 returns int and doesn't produce incompatibility errors.
The fix adds a return value to methods, fixing compatibility issues.