### PR TITLE
Change order of F103C8 clock options to ensure 72 MHz defaults.

### DIFF
--- a/STM32F1/boards.txt
+++ b/STM32F1/boards.txt
@@ -397,6 +397,9 @@ genericSTM32F103C.menu.upload_method.HIDUploadMethod.build.ldscript=ld/hid_bootl
 
 #-- CPU Clock frequency
 
+genericSTM32F103C.menu.cpu_speed.speed_72mhz=72Mhz (Normal)
+genericSTM32F103C.menu.cpu_speed.speed_72mhz.build.f_cpu=72000000L
+
 genericSTM32F103C.menu.cpu_speed.speed_hsi_64mhz=64Mhz (HSI)
 genericSTM32F103C.menu.cpu_speed.speed_hsi_64mhz.build.f_cpu=64000000L
 genericSTM32F103C.menu.cpu_speed.speed_hsi_64mhz.build.hs_flag=-DUSE_HSI_CLOCK
@@ -404,9 +407,6 @@ genericSTM32F103C.menu.cpu_speed.speed_hsi_64mhz.build.hs_flag=-DUSE_HSI_CLOCK
 genericSTM32F103C.menu.cpu_speed.speed_hsi_48mhz=48Mhz (HSI- USB) 
 genericSTM32F103C.menu.cpu_speed.speed_hsi_48mhz.build.f_cpu=48000000L
 genericSTM32F103C.menu.cpu_speed.speed_hsi_48mhz.build.hs_flag=-DUSE_HSI_CLOCK -DHSI_USB_SPEED
-
-genericSTM32F103C.menu.cpu_speed.speed_72mhz=72Mhz (Normal)
-genericSTM32F103C.menu.cpu_speed.speed_72mhz.build.f_cpu=72000000L
 
 genericSTM32F103C.menu.cpu_speed.speed_48mhz=48Mhz (Slow - with USB)
 genericSTM32F103C.menu.cpu_speed.speed_48mhz.build.f_cpu=48000000L


### PR DESCRIPTION
After merging a PR #878 the option "HSI 64 MHz" was added to the first place in the list of clock frequency options for the F103C8 bluepill and therefore became the default setting after changing the board.
This leads to confusion, since for most users, the standard clock option of the bluepill board is "72MHz (Normal)". Also many libraries and existing projects are designed for using with 72 MHz clock option.

This PR simply swaps the F103C8 clock options to restore 72 MHz clock as the default choice.